### PR TITLE
✨ [BE] 관리자 커뮤니티 관리(게시글/신고) 기능 추가

### DIFF
--- a/src/main/java/com/back/admin/common/AdminServiceSupport.java
+++ b/src/main/java/com/back/admin/common/AdminServiceSupport.java
@@ -1,0 +1,44 @@
+package com.back.admin.common;
+
+import com.back.admin.common.exception.AdminException;
+import com.back.global.exception.BaseException;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+// 관리자 서비스 공통 헬퍼 (인증 주체 추출, 일괄 실패 메시지, 페이지 파라미터 보정).
+// 상태를 갖지 않는 정적 유틸.
+public final class AdminServiceSupport {
+
+    private static final int MAX_PAGE_SIZE = 100;
+
+    private AdminServiceSupport() {
+    }
+
+    // 현재 로그인한 관리자 user_id (/api/admin/** 는 SecurityConfig 에서 ADMIN 으로 이미 제한됨)
+    public static Long currentAdminId() {
+        String subValue = SecurityContextHolder.getContext().getAuthentication().getName();
+        try {
+            return Long.parseLong(subValue);
+        } catch (NumberFormatException e) {
+            throw new AdminException("로그인이 필요한 서비스입니다.", HttpStatus.UNAUTHORIZED);
+        }
+    }
+
+    // 일괄 처리 실패 사유 메시지 (도메인 예외는 그대로, 그 외는 일반 메시지)
+    public static String resolveFailureMessage(Exception e) {
+        return (e instanceof BaseException) ? e.getMessage() : "처리 중 오류가 발생했습니다.";
+    }
+
+    // 페이지 번호 보정 (1 미만 방지 → 음수 OFFSET 오류 예방)
+    public static int clampPage(int page) {
+        return Math.max(1, page);
+    }
+
+    // 페이지 크기 보정 (1 ~ MAX_PAGE_SIZE)
+    public static int clampSize(int size) {
+        if (size < 1) {
+            return 1;
+        }
+        return Math.min(size, MAX_PAGE_SIZE);
+    }
+}

--- a/src/main/java/com/back/admin/common/dto/BulkResultResponse.java
+++ b/src/main/java/com/back/admin/common/dto/BulkResultResponse.java
@@ -1,0 +1,29 @@
+package com.back.admin.common.dto;
+
+import java.util.List;
+import lombok.Getter;
+
+// 일괄 처리 결과 (부분 성공). 성공 개수 + 실패 항목(id, 사유) 목록.
+@Getter
+public class BulkResultResponse {
+    private final int successCount;
+    private final int failCount;
+    private final List<FailureItem> failures;
+
+    public BulkResultResponse(int successCount, List<FailureItem> failures) {
+        this.successCount = successCount;
+        this.failCount = failures.size();
+        this.failures = failures;
+    }
+
+    @Getter
+    public static class FailureItem {
+        private final Long id;      // 실패한 대상 id (postId / commentId)
+        private final String message;
+
+        public FailureItem(Long id, String message) {
+            this.id = id;
+            this.message = message;
+        }
+    }
+}

--- a/src/main/java/com/back/admin/common/exception/AdminException.java
+++ b/src/main/java/com/back/admin/common/exception/AdminException.java
@@ -1,0 +1,12 @@
+package com.back.admin.common.exception;
+
+import com.back.global.exception.BaseException;
+import org.springframework.http.HttpStatus;
+
+// 관리자 공통 예외 (특정 도메인에 속하지 않는 관리자 공통 처리용)
+public class AdminException extends BaseException {
+
+    public AdminException(String message, HttpStatus status) {
+        super(message, status);
+    }
+}

--- a/src/main/java/com/back/admin/moderation/dto/ModerationLogEntry.java
+++ b/src/main/java/com/back/admin/moderation/dto/ModerationLogEntry.java
@@ -1,0 +1,27 @@
+package com.back.admin.moderation.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+// moderation_log INSERT 파라미터 겸, 생성된 action_id 를 돌려받는 용도(useGeneratedKeys)
+@Getter
+@Setter
+public class ModerationLogEntry {
+    private Long actionId;       // INSERT 후 채워짐 (keyProperty)
+    private String targetType;   // 'post' / 'comment'
+    private Long targetId;
+    private String appliedState; // normal / blind / deleted
+    private Long reasonId;       // 복원(normal)은 null
+    private String detail;       // ETC 상세 (없으면 null)
+    private Long actedBy;        // 조치 관리자 user_id (null = 시스템)
+
+    public ModerationLogEntry(String targetType, Long targetId, String appliedState,
+                              Long reasonId, String detail, Long actedBy) {
+        this.targetType = targetType;
+        this.targetId = targetId;
+        this.appliedState = appliedState;
+        this.reasonId = reasonId;
+        this.detail = detail;
+        this.actedBy = actedBy;
+    }
+}

--- a/src/main/java/com/back/admin/moderation/dto/ModerationState.java
+++ b/src/main/java/com/back/admin/moderation/dto/ModerationState.java
@@ -1,0 +1,18 @@
+package com.back.admin.moderation.dto;
+
+// 콘텐츠 표시 상태. DB에는 소문자 문자열(normal/blind/deleted)로 저장된다.
+public enum ModerationState {
+    NORMAL("normal"),
+    BLIND("blind"),
+    DELETED("deleted");
+
+    private final String dbValue;
+
+    ModerationState(String dbValue) {
+        this.dbValue = dbValue;
+    }
+
+    public String dbValue() {
+        return dbValue;
+    }
+}

--- a/src/main/java/com/back/admin/moderation/exception/ModerationException.java
+++ b/src/main/java/com/back/admin/moderation/exception/ModerationException.java
@@ -1,0 +1,11 @@
+package com.back.admin.moderation.exception;
+
+import com.back.global.exception.BaseException;
+import org.springframework.http.HttpStatus;
+
+public class ModerationException extends BaseException {
+
+    public ModerationException(String message, HttpStatus status) {
+        super(message, status);
+    }
+}

--- a/src/main/java/com/back/admin/moderation/mapper/ModerationMapper.java
+++ b/src/main/java/com/back/admin/moderation/mapper/ModerationMapper.java
@@ -13,6 +13,12 @@ public interface ModerationMapper {
     // 댓글 표시 상태 변경
     int updateCommentState(@Param("commentId") Long commentId, @Param("state") String state);
 
+    // 게시글 현재 표시 상태 조회 (없으면 null)
+    String findPostState(@Param("postId") Long postId);
+
+    // 댓글 현재 표시 상태 조회 (없으면 null)
+    String findCommentState(@Param("commentId") Long commentId);
+
     // 게시글 작성자 user_id 조회
     Long findPostAuthorId(@Param("postId") Long postId);
 

--- a/src/main/java/com/back/admin/moderation/mapper/ModerationMapper.java
+++ b/src/main/java/com/back/admin/moderation/mapper/ModerationMapper.java
@@ -1,0 +1,39 @@
+package com.back.admin.moderation.mapper;
+
+import com.back.admin.moderation.dto.ModerationLogEntry;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+@Mapper
+public interface ModerationMapper {
+
+    // 게시글 표시 상태 변경 (normal/blind/deleted)
+    int updatePostState(@Param("postId") Long postId, @Param("state") String state);
+
+    // 댓글 표시 상태 변경
+    int updateCommentState(@Param("commentId") Long commentId, @Param("state") String state);
+
+    // 게시글 작성자 user_id 조회
+    Long findPostAuthorId(@Param("postId") Long postId);
+
+    // 댓글 작성자 user_id 조회
+    Long findCommentAuthorId(@Param("commentId") Long commentId);
+
+    // 조치 이력 기록. 성공 시 entry.actionId 에 생성된 PK 가 채워짐
+    void insertModerationLog(@Param("entry") ModerationLogEntry entry);
+
+    // 주의 포인트 적립 (points/시효는 policy_settings 값 사용, 없으면 기본 2/365)
+    void insertPenalty(
+            @Param("userId") Long userId,
+            @Param("targetType") String targetType,
+            @Param("targetId") Long targetId,
+            @Param("sourceActionId") Long sourceActionId
+    );
+
+    // 대상(target)에 걸린 미회수 주의 포인트를 복원 조치로 회수(void)
+    int voidPenaltiesByTarget(
+            @Param("targetType") String targetType,
+            @Param("targetId") Long targetId,
+            @Param("voidActionId") Long voidActionId
+    );
+}

--- a/src/main/java/com/back/admin/moderation/service/ModerationService.java
+++ b/src/main/java/com/back/admin/moderation/service/ModerationService.java
@@ -13,4 +13,7 @@ public interface ModerationService {
 
     // 소프트 삭제: state=deleted + 조치이력 기록 + 작성자에게 주의 포인트 적립(+2)
     void softDelete(String targetType, Long targetId, Long actorId, Long reasonId, String detail);
+
+    // 대상의 현재 표시 상태(normal/blind/deleted) 조회. 없으면 null.
+    String currentState(String targetType, Long targetId);
 }

--- a/src/main/java/com/back/admin/moderation/service/ModerationService.java
+++ b/src/main/java/com/back/admin/moderation/service/ModerationService.java
@@ -1,0 +1,16 @@
+package com.back.admin.moderation.service;
+
+// 게시글/댓글에 대한 공통 조치(블라인드/복원/삭제) 로직.
+// 게시글 관리·신고 관리 두 페이지가 공유한다.
+// targetType 은 "post" 또는 "comment".
+public interface ModerationService {
+
+    // 블라인드: state=blind + 조치이력 기록 (주의 포인트 없음)
+    void blind(String targetType, Long targetId, Long actorId, Long reasonId, String detail);
+
+    // 복원(공개/반려): state=normal + 조치이력 기록 + 관련 주의 포인트 회수(void)
+    void restore(String targetType, Long targetId, Long actorId);
+
+    // 소프트 삭제: state=deleted + 조치이력 기록 + 작성자에게 주의 포인트 적립(+2)
+    void softDelete(String targetType, Long targetId, Long actorId, Long reasonId, String detail);
+}

--- a/src/main/java/com/back/admin/moderation/service/ModerationServiceImpl.java
+++ b/src/main/java/com/back/admin/moderation/service/ModerationServiceImpl.java
@@ -1,0 +1,82 @@
+package com.back.admin.moderation.service;
+
+import com.back.admin.moderation.dto.ModerationLogEntry;
+import com.back.admin.moderation.dto.ModerationState;
+import com.back.admin.moderation.exception.ModerationException;
+import com.back.admin.moderation.mapper.ModerationMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ModerationServiceImpl implements ModerationService {
+
+    public static final String TARGET_POST = "post";
+    public static final String TARGET_COMMENT = "comment";
+
+    private final ModerationMapper moderationMapper;
+
+    @Override
+    public void blind(String targetType, Long targetId, Long actorId, Long reasonId, String detail) {
+        applyState(targetType, targetId, ModerationState.BLIND);
+        writeLog(targetType, targetId, ModerationState.BLIND, reasonId, detail, actorId);
+    }
+
+    @Override
+    public void restore(String targetType, Long targetId, Long actorId) {
+        applyState(targetType, targetId, ModerationState.NORMAL);
+        // 복원은 사유 없음(reasonId=null). 조치 이력을 남기고 그 action_id 로 주의 포인트를 회수한다.
+        ModerationLogEntry entry = writeLog(targetType, targetId, ModerationState.NORMAL, null, null, actorId);
+        moderationMapper.voidPenaltiesByTarget(targetType, targetId, entry.getActionId());
+    }
+
+    @Override
+    public void softDelete(String targetType, Long targetId, Long actorId, Long reasonId, String detail) {
+        applyState(targetType, targetId, ModerationState.DELETED);
+        ModerationLogEntry entry = writeLog(targetType, targetId, ModerationState.DELETED, reasonId, detail, actorId);
+
+        Long authorId = findAuthorId(targetType, targetId);
+        if (authorId == null) {
+            throw new ModerationException("작성자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+        }
+        // 작성자에게 주의 포인트 적립 (+2, 시효는 policy_settings 기준)
+        moderationMapper.insertPenalty(authorId, targetType, targetId, entry.getActionId());
+    }
+
+    // ---- 내부 헬퍼 ----
+
+    // targetType 에 맞는 테이블의 state 를 변경. 대상이 없으면 예외.
+    private void applyState(String targetType, Long targetId, ModerationState state) {
+        int updated;
+        if (TARGET_POST.equals(targetType)) {
+            updated = moderationMapper.updatePostState(targetId, state.dbValue());
+        } else if (TARGET_COMMENT.equals(targetType)) {
+            updated = moderationMapper.updateCommentState(targetId, state.dbValue());
+        } else {
+            throw new ModerationException("잘못된 대상 유형입니다: " + targetType, HttpStatus.BAD_REQUEST);
+        }
+        if (updated == 0) {
+            throw new ModerationException("대상을 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+        }
+    }
+
+    private ModerationLogEntry writeLog(String targetType, Long targetId, ModerationState state,
+                                        Long reasonId, String detail, Long actorId) {
+        ModerationLogEntry entry = new ModerationLogEntry(
+                targetType, targetId, state.dbValue(), reasonId, detail, actorId);
+        moderationMapper.insertModerationLog(entry);
+        return entry;
+    }
+
+    private Long findAuthorId(String targetType, Long targetId) {
+        if (TARGET_POST.equals(targetType)) {
+            return moderationMapper.findPostAuthorId(targetId);
+        } else if (TARGET_COMMENT.equals(targetType)) {
+            return moderationMapper.findCommentAuthorId(targetId);
+        }
+        throw new ModerationException("잘못된 대상 유형입니다: " + targetType, HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/com/back/admin/moderation/service/ModerationServiceImpl.java
+++ b/src/main/java/com/back/admin/moderation/service/ModerationServiceImpl.java
@@ -21,13 +21,13 @@ public class ModerationServiceImpl implements ModerationService {
 
     @Override
     public void blind(String targetType, Long targetId, Long actorId, Long reasonId, String detail) {
-        applyState(targetType, targetId, ModerationState.BLIND);
+        if (!changeState(targetType, targetId, ModerationState.BLIND)) return; // 이미 blind면 no-op
         writeLog(targetType, targetId, ModerationState.BLIND, reasonId, detail, actorId);
     }
 
     @Override
     public void restore(String targetType, Long targetId, Long actorId) {
-        applyState(targetType, targetId, ModerationState.NORMAL);
+        if (!changeState(targetType, targetId, ModerationState.NORMAL)) return; // 이미 normal이면 no-op
         // 복원은 사유 없음(reasonId=null). 조치 이력을 남기고 그 action_id 로 주의 포인트를 회수한다.
         ModerationLogEntry entry = writeLog(targetType, targetId, ModerationState.NORMAL, null, null, actorId);
         moderationMapper.voidPenaltiesByTarget(targetType, targetId, entry.getActionId());
@@ -35,7 +35,7 @@ public class ModerationServiceImpl implements ModerationService {
 
     @Override
     public void softDelete(String targetType, Long targetId, Long actorId, Long reasonId, String detail) {
-        applyState(targetType, targetId, ModerationState.DELETED);
+        if (!changeState(targetType, targetId, ModerationState.DELETED)) return; // 이미 deleted면 no-op (벌점 중복 방지)
         ModerationLogEntry entry = writeLog(targetType, targetId, ModerationState.DELETED, reasonId, detail, actorId);
 
         Long authorId = findAuthorId(targetType, targetId);
@@ -46,10 +46,22 @@ public class ModerationServiceImpl implements ModerationService {
         moderationMapper.insertPenalty(authorId, targetType, targetId, entry.getActionId());
     }
 
+    @Override
+    public String currentState(String targetType, Long targetId) {
+        if (TARGET_POST.equals(targetType)) {
+            return moderationMapper.findPostState(targetId);
+        } else if (TARGET_COMMENT.equals(targetType)) {
+            return moderationMapper.findCommentState(targetId);
+        }
+        throw new ModerationException("잘못된 대상 유형입니다: " + targetType, HttpStatus.BAD_REQUEST);
+    }
+
     // ---- 내부 헬퍼 ----
 
-    // targetType 에 맞는 테이블의 state 를 변경. 대상이 없으면 예외.
-    private void applyState(String targetType, Long targetId, ModerationState state) {
+    // 상태를 변경한다. 실제로 바뀌면 true, 이미 같은 상태면 false(no-op), 대상이 없으면 예외.
+    // 조건부 UPDATE(state <> #{state})로 원자적 처리 → 동시 요청/재시도에도 중복 로그·벌점 방지.
+    // (이미 그 상태인 행은 WHERE 에 걸리지 않아 0건 반환 → CLIENT_FOUND_ROWS 모드에서도 신뢰 가능)
+    private boolean changeState(String targetType, Long targetId, ModerationState state) {
         int updated;
         if (TARGET_POST.equals(targetType)) {
             updated = moderationMapper.updatePostState(targetId, state.dbValue());
@@ -58,9 +70,14 @@ public class ModerationServiceImpl implements ModerationService {
         } else {
             throw new ModerationException("잘못된 대상 유형입니다: " + targetType, HttpStatus.BAD_REQUEST);
         }
-        if (updated == 0) {
+        if (updated > 0) {
+            return true; // 실제로 상태가 바뀜
+        }
+        // 0건: 이미 목표 상태이거나 대상이 없음 → 존재 여부로 구분
+        if (currentState(targetType, targetId) == null) {
             throw new ModerationException("대상을 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
         }
+        return false; // 이미 목표 상태 → no-op
     }
 
     private ModerationLogEntry writeLog(String targetType, Long targetId, ModerationState state,

--- a/src/main/java/com/back/admin/post/controller/AdminPostController.java
+++ b/src/main/java/com/back/admin/post/controller/AdminPostController.java
@@ -1,6 +1,7 @@
 package com.back.admin.post.controller;
 
 import com.back.admin.common.dto.BulkResultResponse;
+import com.back.admin.post.dto.AdminPostDetailResponse;
 import com.back.admin.post.dto.AdminPostPageResponse;
 import com.back.admin.post.dto.AdminPostResponse;
 import com.back.admin.post.dto.BulkPostDeleteRequest;
@@ -27,6 +28,13 @@ public class AdminPostController {
             @RequestParam(value = "keyword", required = false) String keyword) {
         log.info("[관리자] 게시글 목록 조회 - page:{}, size:{}, boardId:{}, keyword:{}", page, size, boardId, keyword);
         return ResponseEntity.ok(adminPostService.getPostList(page, size, boardId, keyword));
+    }
+
+    // 게시글 상세 (블라인드/삭제 글도 열람, 댓글·첨부 포함)
+    @GetMapping("/api/admin/posts/{postId}")
+    public ResponseEntity<AdminPostDetailResponse> getPostDetail(@PathVariable Long postId) {
+        log.info("[관리자] 게시글 상세 조회 - postId:{}", postId);
+        return ResponseEntity.ok(adminPostService.getPostDetail(postId));
     }
 
     // 블라인드

--- a/src/main/java/com/back/admin/post/controller/AdminPostController.java
+++ b/src/main/java/com/back/admin/post/controller/AdminPostController.java
@@ -1,0 +1,67 @@
+package com.back.admin.post.controller;
+
+import com.back.admin.common.dto.BulkResultResponse;
+import com.back.admin.post.dto.AdminPostPageResponse;
+import com.back.admin.post.dto.AdminPostResponse;
+import com.back.admin.post.dto.BulkPostDeleteRequest;
+import com.back.admin.post.dto.PostModerationRequest;
+import com.back.admin.post.service.AdminPostService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class AdminPostController {
+
+    private final AdminPostService adminPostService;
+
+    // 전체 게시글 목록 (최신순, 게시판 필터, 제목+글쓴이 검색, 페이징)
+    @GetMapping("/api/admin/posts")
+    public ResponseEntity<AdminPostPageResponse> getPosts(
+            @RequestParam(value = "page", defaultValue = "1") int page,
+            @RequestParam(value = "size", defaultValue = "10") int size,
+            @RequestParam(value = "boardId", required = false) Long boardId,
+            @RequestParam(value = "keyword", required = false) String keyword) {
+        log.info("[관리자] 게시글 목록 조회 - page:{}, size:{}, boardId:{}, keyword:{}", page, size, boardId, keyword);
+        return ResponseEntity.ok(adminPostService.getPostList(page, size, boardId, keyword));
+    }
+
+    // 블라인드
+    @PatchMapping("/api/admin/posts/{postId}/blind")
+    public ResponseEntity<AdminPostResponse> blindPost(
+            @PathVariable Long postId,
+            @RequestBody PostModerationRequest request) {
+        log.info("[관리자] 게시글 블라인드 - postId:{}, reasonId:{}", postId, request.getReasonId());
+        adminPostService.blindPost(postId, request.getReasonId(), request.getDetail());
+        return ResponseEntity.ok(new AdminPostResponse("블라인드 처리되었습니다."));
+    }
+
+    // 공개(복원)
+    @PatchMapping("/api/admin/posts/{postId}/restore")
+    public ResponseEntity<AdminPostResponse> restorePost(@PathVariable Long postId) {
+        log.info("[관리자] 게시글 공개(복원) - postId:{}", postId);
+        adminPostService.restorePost(postId);
+        return ResponseEntity.ok(new AdminPostResponse("공개 상태로 복원되었습니다."));
+    }
+
+    // 소프트 삭제
+    @DeleteMapping("/api/admin/posts/{postId}")
+    public ResponseEntity<AdminPostResponse> deletePost(
+            @PathVariable Long postId,
+            @RequestBody PostModerationRequest request) {
+        log.info("[관리자] 게시글 삭제 - postId:{}, reasonId:{}", postId, request.getReasonId());
+        adminPostService.deletePost(postId, request.getReasonId(), request.getDetail());
+        return ResponseEntity.ok(new AdminPostResponse("삭제되었습니다."));
+    }
+
+    // 선택 삭제 (일괄, 부분 성공) — 성공 개수 + 실패 항목(id, 사유) 반환
+    @PostMapping("/api/admin/posts/bulk-delete")
+    public ResponseEntity<BulkResultResponse> bulkDeletePosts(@RequestBody BulkPostDeleteRequest request) {
+        log.info("[관리자] 게시글 선택 삭제 - count:{}", request.getPostIds() == null ? 0 : request.getPostIds().size());
+        BulkResultResponse result = adminPostService.bulkDeletePosts(request.getPostIds(), request.getReasonId(), request.getDetail());
+        return ResponseEntity.ok(result);
+    }
+}

--- a/src/main/java/com/back/admin/post/dto/AdminAttachmentResponse.java
+++ b/src/main/java/com/back/admin/post/dto/AdminAttachmentResponse.java
@@ -1,0 +1,14 @@
+package com.back.admin.post.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+// 관리자 상세의 첨부파일
+@Getter
+@Setter
+public class AdminAttachmentResponse {
+    private Long attachmentId;
+    private String originName;
+    private Long fileSize;
+    private String fileUrl;
+}

--- a/src/main/java/com/back/admin/post/dto/AdminCommentResponse.java
+++ b/src/main/java/com/back/admin/post/dto/AdminCommentResponse.java
@@ -1,0 +1,20 @@
+package com.back.admin.post.dto;
+
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.Setter;
+
+// 관리자 상세의 댓글 (모든 state 포함 — 블라인드/삭제 댓글도 노출)
+@Getter
+@Setter
+public class AdminCommentResponse {
+    private Long commentId;
+    private String content;
+    private Long userId;
+    private String authorName;
+    private boolean isAnonymous;
+    private boolean isPrivate;
+    private String state;          // normal / blind / deleted
+    private LocalDateTime created;
+    private LocalDateTime updated;
+}

--- a/src/main/java/com/back/admin/post/dto/AdminPostDetailResponse.java
+++ b/src/main/java/com/back/admin/post/dto/AdminPostDetailResponse.java
@@ -1,0 +1,30 @@
+package com.back.admin.post.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
+
+// 관리자 게시글 상세 (state 무관 조회 — 블라인드/삭제 글도 열람, 댓글·첨부 포함)
+@Getter
+@Setter
+public class AdminPostDetailResponse {
+    private Long postId;
+    private Long boardId;
+    private String boardCode;
+    private String categoryName;   // 카테고리 미사용 게시판이면 null
+    private String title;
+    private String content;
+    private Long authorId;
+    private String authorName;     // 익명글도 실제 작성자명
+    private boolean isAnonymous;
+    private boolean isPinned;
+    private int viewCount;
+    private int likeCount;
+    private int commentCount;      // 전체(모든 state) 기준
+    private String state;          // normal / blind / deleted
+    private LocalDateTime created;
+    private LocalDateTime updated;
+    private List<AdminAttachmentResponse> attachments;
+    private List<AdminCommentResponse> comments;   // 블라인드/삭제 댓글까지 포함
+}

--- a/src/main/java/com/back/admin/post/dto/AdminPostListResponse.java
+++ b/src/main/java/com/back/admin/post/dto/AdminPostListResponse.java
@@ -1,0 +1,21 @@
+package com.back.admin.post.dto;
+
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.Setter;
+
+// 게시글 관리 목록 한 행
+@Getter
+@Setter
+public class AdminPostListResponse {
+    private Long postId;
+    private Long boardId;
+    private String boardCode;    // boards.code (영문 식별자). 한글 표기는 프론트에서 매핑
+    private String title;
+    private String authorName;   // 관리자 화면에는 익명글도 실제 작성자명 표시
+    private int commentCount;
+    private int likeCount;
+    private int viewCount;
+    private LocalDateTime created;
+    private String state;        // normal / blind (deleted 는 목록에서 제외)
+}

--- a/src/main/java/com/back/admin/post/dto/AdminPostPageResponse.java
+++ b/src/main/java/com/back/admin/post/dto/AdminPostPageResponse.java
@@ -1,0 +1,14 @@
+package com.back.admin.post.dto;
+
+import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
+
+// 게시글 관리 목록 페이지 응답
+@Getter
+@Setter
+public class AdminPostPageResponse {
+    private int totalPages;
+    private int totalCount;
+    private List<AdminPostListResponse> posts;
+}

--- a/src/main/java/com/back/admin/post/dto/AdminPostResponse.java
+++ b/src/main/java/com/back/admin/post/dto/AdminPostResponse.java
@@ -1,0 +1,11 @@
+package com.back.admin.post.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+// 조치 결과 메시지 응답 (기존 FreeResponse 와 동일한 형태)
+@Getter
+@AllArgsConstructor
+public class AdminPostResponse {
+    private String message;
+}

--- a/src/main/java/com/back/admin/post/dto/BulkPostDeleteRequest.java
+++ b/src/main/java/com/back/admin/post/dto/BulkPostDeleteRequest.java
@@ -1,0 +1,14 @@
+package com.back.admin.post.dto;
+
+import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
+
+// 선택 삭제(일괄). 사유는 선택된 게시글 전체에 동일 적용.
+@Getter
+@Setter
+public class BulkPostDeleteRequest {
+    private List<Long> postIds;
+    private Long reasonId;
+    private String detail;
+}

--- a/src/main/java/com/back/admin/post/dto/PostModerationRequest.java
+++ b/src/main/java/com/back/admin/post/dto/PostModerationRequest.java
@@ -1,0 +1,12 @@
+package com.back.admin.post.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+// 블라인드/삭제 시 모달에서 선택한 사유. 복원(공개)에는 사용하지 않음.
+@Getter
+@Setter
+public class PostModerationRequest {
+    private Long reasonId;   // reasons.reason_id
+    private String detail;   // ETC(기타) 선택 시 상세 사유, 그 외 null
+}

--- a/src/main/java/com/back/admin/post/exception/AdminPostException.java
+++ b/src/main/java/com/back/admin/post/exception/AdminPostException.java
@@ -1,0 +1,11 @@
+package com.back.admin.post.exception;
+
+import com.back.global.exception.BaseException;
+import org.springframework.http.HttpStatus;
+
+public class AdminPostException extends BaseException {
+
+    public AdminPostException(String message, HttpStatus status) {
+        super(message, status);
+    }
+}

--- a/src/main/java/com/back/admin/post/mapper/AdminPostMapper.java
+++ b/src/main/java/com/back/admin/post/mapper/AdminPostMapper.java
@@ -1,5 +1,8 @@
 package com.back.admin.post.mapper;
 
+import com.back.admin.post.dto.AdminAttachmentResponse;
+import com.back.admin.post.dto.AdminCommentResponse;
+import com.back.admin.post.dto.AdminPostDetailResponse;
 import com.back.admin.post.dto.AdminPostListResponse;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
@@ -23,4 +26,13 @@ public interface AdminPostMapper {
             @Param("boardId") Long boardId,
             @Param("keyword") String keyword
     );
+
+    // 게시글 상세 (state 필터 없음 → 블라인드/삭제 글도 조회). 없으면 null
+    AdminPostDetailResponse findPostDetail(@Param("postId") Long postId);
+
+    // 게시글의 첨부파일 목록
+    List<AdminAttachmentResponse> findAttachments(@Param("postId") Long postId);
+
+    // 게시글의 댓글 목록 (모든 state 포함)
+    List<AdminCommentResponse> findComments(@Param("postId") Long postId);
 }

--- a/src/main/java/com/back/admin/post/mapper/AdminPostMapper.java
+++ b/src/main/java/com/back/admin/post/mapper/AdminPostMapper.java
@@ -1,0 +1,26 @@
+package com.back.admin.post.mapper;
+
+import com.back.admin.post.dto.AdminPostListResponse;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+
+@Mapper
+public interface AdminPostMapper {
+
+    // 전체 게시글 목록 (모든 게시판 통합, 최신순, 게시판 필터, 제목+글쓴이 검색, 페이징)
+    // deleted 상태는 제외한다.
+    List<AdminPostListResponse> findPosts(
+            @Param("boardId") Long boardId,
+            @Param("keyword") String keyword,
+            @Param("offset") int offset,
+            @Param("size") int size
+    );
+
+    // 위 조건에 해당하는 총 개수 (페이징 계산용)
+    int countPosts(
+            @Param("boardId") Long boardId,
+            @Param("keyword") String keyword
+    );
+}

--- a/src/main/java/com/back/admin/post/service/AdminPostService.java
+++ b/src/main/java/com/back/admin/post/service/AdminPostService.java
@@ -1,0 +1,24 @@
+package com.back.admin.post.service;
+
+import com.back.admin.common.dto.BulkResultResponse;
+import com.back.admin.post.dto.AdminPostPageResponse;
+
+import java.util.List;
+
+public interface AdminPostService {
+
+    // 전체 게시글 목록 조회 (최신순, 게시판 필터, 제목+글쓴이 검색, 페이징)
+    AdminPostPageResponse getPostList(int page, int size, Long boardId, String keyword);
+
+    // 블라인드 처리 (사유 필수 모달)
+    void blindPost(Long postId, Long reasonId, String detail);
+
+    // 공개(복원)
+    void restorePost(Long postId);
+
+    // 소프트 삭제 (사유 모달 + 작성자 주의 +2)
+    void deletePost(Long postId, Long reasonId, String detail);
+
+    // 선택 삭제 (일괄, 부분 성공) — 성공 개수 + 실패 항목(id, 사유) 반환
+    BulkResultResponse bulkDeletePosts(List<Long> postIds, Long reasonId, String detail);
+}

--- a/src/main/java/com/back/admin/post/service/AdminPostService.java
+++ b/src/main/java/com/back/admin/post/service/AdminPostService.java
@@ -1,6 +1,7 @@
 package com.back.admin.post.service;
 
 import com.back.admin.common.dto.BulkResultResponse;
+import com.back.admin.post.dto.AdminPostDetailResponse;
 import com.back.admin.post.dto.AdminPostPageResponse;
 
 import java.util.List;
@@ -9,6 +10,9 @@ public interface AdminPostService {
 
     // 전체 게시글 목록 조회 (최신순, 게시판 필터, 제목+글쓴이 검색, 페이징)
     AdminPostPageResponse getPostList(int page, int size, Long boardId, String keyword);
+
+    // 게시글 상세 (state 무관, 댓글·첨부 포함)
+    AdminPostDetailResponse getPostDetail(Long postId);
 
     // 블라인드 처리 (사유 필수 모달)
     void blindPost(Long postId, Long reasonId, String detail);

--- a/src/main/java/com/back/admin/post/service/AdminPostServiceImpl.java
+++ b/src/main/java/com/back/admin/post/service/AdminPostServiceImpl.java
@@ -1,0 +1,102 @@
+package com.back.admin.post.service;
+
+import com.back.admin.common.dto.BulkResultResponse;
+import com.back.admin.moderation.service.ModerationService;
+import com.back.admin.post.dto.AdminPostListResponse;
+import com.back.admin.post.dto.AdminPostPageResponse;
+import com.back.admin.post.exception.AdminPostException;
+import com.back.admin.post.mapper.AdminPostMapper;
+import com.back.global.exception.BaseException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.CollectionUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.back.admin.moderation.service.ModerationServiceImpl.TARGET_POST;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminPostServiceImpl implements AdminPostService {
+
+    private final AdminPostMapper adminPostMapper;
+    private final ModerationService moderationService;
+    private final PostBulkExecutor postBulkExecutor;
+
+    // 현재 로그인한 관리자 user_id 추출 (/api/admin/** 는 SecurityConfig 에서 ADMIN 으로 이미 제한됨)
+    private Long getCurrentAdminId() {
+        String subValue = SecurityContextHolder.getContext().getAuthentication().getName();
+        try {
+            return Long.parseLong(subValue);
+        } catch (NumberFormatException e) {
+            throw new AdminPostException("로그인이 필요한 서비스입니다.", HttpStatus.UNAUTHORIZED);
+        }
+    }
+
+    @Override
+    public AdminPostPageResponse getPostList(int page, int size, Long boardId, String keyword) {
+        int totalCount = adminPostMapper.countPosts(boardId, keyword);
+        int totalPages = (int) Math.ceil((double) totalCount / size);
+
+        int offset = (page - 1) * size;
+        List<AdminPostListResponse> posts = adminPostMapper.findPosts(boardId, keyword, offset, size);
+
+        AdminPostPageResponse response = new AdminPostPageResponse();
+        response.setTotalCount(totalCount);
+        response.setTotalPages(totalPages);
+        response.setPosts(posts);
+        return response;
+    }
+
+    @Override
+    @Transactional
+    public void blindPost(Long postId, Long reasonId, String detail) {
+        Long adminId = getCurrentAdminId();
+        moderationService.blind(TARGET_POST, postId, adminId, reasonId, detail);
+    }
+
+    @Override
+    @Transactional
+    public void restorePost(Long postId) {
+        Long adminId = getCurrentAdminId();
+        moderationService.restore(TARGET_POST, postId, adminId);
+    }
+
+    @Override
+    public void deletePost(Long postId, Long reasonId, String detail) {
+        Long adminId = getCurrentAdminId();
+        // 항목별 독립 트랜잭션으로 실행 (단건도 동일 경로 사용)
+        postBulkExecutor.deletePost(postId, adminId, reasonId, detail);
+    }
+
+    @Override
+    public BulkResultResponse bulkDeletePosts(List<Long> postIds, Long reasonId, String detail) {
+        if (CollectionUtils.isEmpty(postIds)) {
+            throw new AdminPostException("삭제할 게시글을 선택해 주세요.", HttpStatus.BAD_REQUEST);
+        }
+        Long adminId = getCurrentAdminId();
+
+        int successCount = 0;
+        List<BulkResultResponse.FailureItem> failures = new ArrayList<>();
+        for (Long postId : postIds) {
+            try {
+                postBulkExecutor.deletePost(postId, adminId, reasonId, detail);
+                successCount++;
+            } catch (Exception e) {
+                // 한 건 실패는 다른 건에 영향 없음 (REQUIRES_NEW). 실패 사유 수집
+                failures.add(new BulkResultResponse.FailureItem(postId, resolveMessage(e)));
+            }
+        }
+        return new BulkResultResponse(successCount, failures);
+    }
+
+    // 실패 사유 메시지 추출 (도메인 예외는 그대로, 그 외는 일반 메시지)
+    private String resolveMessage(Exception e) {
+        return (e instanceof BaseException) ? e.getMessage() : "처리 중 오류가 발생했습니다.";
+    }
+}

--- a/src/main/java/com/back/admin/post/service/AdminPostServiceImpl.java
+++ b/src/main/java/com/back/admin/post/service/AdminPostServiceImpl.java
@@ -1,20 +1,21 @@
 package com.back.admin.post.service;
 
+import com.back.admin.common.AdminServiceSupport;
 import com.back.admin.common.dto.BulkResultResponse;
 import com.back.admin.moderation.service.ModerationService;
+import com.back.admin.post.dto.AdminPostDetailResponse;
 import com.back.admin.post.dto.AdminPostListResponse;
 import com.back.admin.post.dto.AdminPostPageResponse;
 import com.back.admin.post.exception.AdminPostException;
 import com.back.admin.post.mapper.AdminPostMapper;
-import com.back.global.exception.BaseException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.CollectionUtils;
 
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 
 import static com.back.admin.moderation.service.ModerationServiceImpl.TARGET_POST;
@@ -28,18 +29,11 @@ public class AdminPostServiceImpl implements AdminPostService {
     private final ModerationService moderationService;
     private final PostBulkExecutor postBulkExecutor;
 
-    // 현재 로그인한 관리자 user_id 추출 (/api/admin/** 는 SecurityConfig 에서 ADMIN 으로 이미 제한됨)
-    private Long getCurrentAdminId() {
-        String subValue = SecurityContextHolder.getContext().getAuthentication().getName();
-        try {
-            return Long.parseLong(subValue);
-        } catch (NumberFormatException e) {
-            throw new AdminPostException("로그인이 필요한 서비스입니다.", HttpStatus.UNAUTHORIZED);
-        }
-    }
-
     @Override
     public AdminPostPageResponse getPostList(int page, int size, Long boardId, String keyword) {
+        page = AdminServiceSupport.clampPage(page);
+        size = AdminServiceSupport.clampSize(size);
+
         int totalCount = adminPostMapper.countPosts(boardId, keyword);
         int totalPages = (int) Math.ceil((double) totalCount / size);
 
@@ -54,24 +48,33 @@ public class AdminPostServiceImpl implements AdminPostService {
     }
 
     @Override
+    public AdminPostDetailResponse getPostDetail(Long postId) {
+        // state 필터 없이 조회 → 블라인드/삭제 글도 열람. 조회수는 올리지 않음.
+        AdminPostDetailResponse detail = adminPostMapper.findPostDetail(postId);
+        if (detail == null) {
+            throw new AdminPostException("존재하지 않는 게시글입니다.", HttpStatus.NOT_FOUND);
+        }
+        detail.setAttachments(adminPostMapper.findAttachments(postId));
+        detail.setComments(adminPostMapper.findComments(postId));  // 블라인드/삭제 댓글까지 포함
+        return detail;
+    }
+
+    @Override
     @Transactional
     public void blindPost(Long postId, Long reasonId, String detail) {
-        Long adminId = getCurrentAdminId();
-        moderationService.blind(TARGET_POST, postId, adminId, reasonId, detail);
+        moderationService.blind(TARGET_POST, postId, AdminServiceSupport.currentAdminId(), reasonId, detail);
     }
 
     @Override
     @Transactional
     public void restorePost(Long postId) {
-        Long adminId = getCurrentAdminId();
-        moderationService.restore(TARGET_POST, postId, adminId);
+        moderationService.restore(TARGET_POST, postId, AdminServiceSupport.currentAdminId());
     }
 
     @Override
     public void deletePost(Long postId, Long reasonId, String detail) {
-        Long adminId = getCurrentAdminId();
         // 항목별 독립 트랜잭션으로 실행 (단건도 동일 경로 사용)
-        postBulkExecutor.deletePost(postId, adminId, reasonId, detail);
+        postBulkExecutor.deletePost(postId, AdminServiceSupport.currentAdminId(), reasonId, detail);
     }
 
     @Override
@@ -79,24 +82,20 @@ public class AdminPostServiceImpl implements AdminPostService {
         if (CollectionUtils.isEmpty(postIds)) {
             throw new AdminPostException("삭제할 게시글을 선택해 주세요.", HttpStatus.BAD_REQUEST);
         }
-        Long adminId = getCurrentAdminId();
+        Long adminId = AdminServiceSupport.currentAdminId();
 
         int successCount = 0;
         List<BulkResultResponse.FailureItem> failures = new ArrayList<>();
-        for (Long postId : postIds) {
+        // 요청 내 중복 id 제거 (중복 조치로 인한 불필요한 반복 방지)
+        for (Long postId : new LinkedHashSet<>(postIds)) {
             try {
                 postBulkExecutor.deletePost(postId, adminId, reasonId, detail);
                 successCount++;
             } catch (Exception e) {
                 // 한 건 실패는 다른 건에 영향 없음 (REQUIRES_NEW). 실패 사유 수집
-                failures.add(new BulkResultResponse.FailureItem(postId, resolveMessage(e)));
+                failures.add(new BulkResultResponse.FailureItem(postId, AdminServiceSupport.resolveFailureMessage(e)));
             }
         }
         return new BulkResultResponse(successCount, failures);
-    }
-
-    // 실패 사유 메시지 추출 (도메인 예외는 그대로, 그 외는 일반 메시지)
-    private String resolveMessage(Exception e) {
-        return (e instanceof BaseException) ? e.getMessage() : "처리 중 오류가 발생했습니다.";
     }
 }

--- a/src/main/java/com/back/admin/post/service/PostBulkExecutor.java
+++ b/src/main/java/com/back/admin/post/service/PostBulkExecutor.java
@@ -1,6 +1,8 @@
 package com.back.admin.post.service;
 
 import com.back.admin.moderation.service.ModerationService;
+import com.back.admin.report.dto.ReportStatus;
+import com.back.admin.report.mapper.AdminReportMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
@@ -16,9 +18,13 @@ import static com.back.admin.moderation.service.ModerationServiceImpl.TARGET_POS
 public class PostBulkExecutor {
 
     private final ModerationService moderationService;
+    private final AdminReportMapper adminReportMapper;
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void deletePost(Long postId, Long adminId, Long reasonId, String detail) {
         moderationService.softDelete(TARGET_POST, postId, adminId, reasonId, detail);
+        // 삭제 시 해당 게시글의 미처리(pending) 신고도 함께 종료 (게시글 관리 ↔ 신고 관리 상태 일치).
+        // 신고가 없으면 0건 갱신되어 무해.
+        adminReportMapper.updatePendingReportsStatus(TARGET_POST, postId, ReportStatus.RESOLVED.dbValue());
     }
 }

--- a/src/main/java/com/back/admin/post/service/PostBulkExecutor.java
+++ b/src/main/java/com/back/admin/post/service/PostBulkExecutor.java
@@ -1,0 +1,24 @@
+package com.back.admin.post.service;
+
+import com.back.admin.moderation.service.ModerationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.back.admin.moderation.service.ModerationServiceImpl.TARGET_POST;
+
+// 게시글 1건 조치를 "독립 트랜잭션"으로 실행하는 컴포넌트.
+// 일괄 처리 시 한 건이 실패해도 다른 건에 영향이 없도록 REQUIRES_NEW 로 분리한다.
+// (별도 빈이라 프록시를 타므로 self-invocation 문제도 없음)
+@Component
+@RequiredArgsConstructor
+public class PostBulkExecutor {
+
+    private final ModerationService moderationService;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void deletePost(Long postId, Long adminId, Long reasonId, String detail) {
+        moderationService.softDelete(TARGET_POST, postId, adminId, reasonId, detail);
+    }
+}

--- a/src/main/java/com/back/admin/report/controller/AdminReportController.java
+++ b/src/main/java/com/back/admin/report/controller/AdminReportController.java
@@ -1,0 +1,81 @@
+package com.back.admin.report.controller;
+
+import com.back.admin.common.dto.BulkResultResponse;
+import com.back.admin.report.dto.AdminReportResponse;
+import com.back.admin.report.dto.ReportBulkRequest;
+import com.back.admin.report.dto.ReportPageResponse;
+import com.back.admin.report.service.AdminReportService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class AdminReportController {
+
+    private final AdminReportService adminReportService;
+
+    // 게시글 신고 목록 (status: pending/rejected/resolved, 프론트 표기 블라인드/반려/삭제)
+    @GetMapping("/api/admin/reports/posts")
+    public ResponseEntity<ReportPageResponse> getReportedPosts(
+            @RequestParam(value = "page", defaultValue = "1") int page,
+            @RequestParam(value = "size", defaultValue = "10") int size,
+            @RequestParam(value = "status", required = false) String status,
+            @RequestParam(value = "boardId", required = false) Long boardId,
+            @RequestParam(value = "sort", defaultValue = "latest") String sort) {
+        log.info("[관리자] 게시글 신고 목록 - status:{}, boardId:{}, sort:{}", status, boardId, sort);
+        return ResponseEntity.ok(adminReportService.getReportedPosts(page, size, status, boardId, sort));
+    }
+
+    // 댓글 신고 목록
+    @GetMapping("/api/admin/reports/comments")
+    public ResponseEntity<ReportPageResponse> getReportedComments(
+            @RequestParam(value = "page", defaultValue = "1") int page,
+            @RequestParam(value = "size", defaultValue = "10") int size,
+            @RequestParam(value = "status", required = false) String status,
+            @RequestParam(value = "boardId", required = false) Long boardId,
+            @RequestParam(value = "sort", defaultValue = "latest") String sort) {
+        log.info("[관리자] 댓글 신고 목록 - status:{}, boardId:{}, sort:{}", status, boardId, sort);
+        return ResponseEntity.ok(adminReportService.getReportedComments(page, size, status, boardId, sort));
+    }
+
+    // 반려 (단건)
+    @PatchMapping("/api/admin/reports/{targetType}/{targetId}/reject")
+    public ResponseEntity<AdminReportResponse> reject(
+            @PathVariable String targetType,
+            @PathVariable Long targetId) {
+        log.info("[관리자] 신고 반려 - {}:{}", targetType, targetId);
+        adminReportService.reject(targetType, targetId);
+        return ResponseEntity.ok(new AdminReportResponse("반려 처리되었습니다."));
+    }
+
+    // 삭제 (단건)
+    @DeleteMapping("/api/admin/reports/{targetType}/{targetId}")
+    public ResponseEntity<AdminReportResponse> delete(
+            @PathVariable String targetType,
+            @PathVariable Long targetId) {
+        log.info("[관리자] 신고 삭제 - {}:{}", targetType, targetId);
+        adminReportService.delete(targetType, targetId);
+        return ResponseEntity.ok(new AdminReportResponse("삭제되었습니다."));
+    }
+
+    // 선택 반려 (일괄, 부분 성공)
+    @PostMapping("/api/admin/reports/bulk-reject")
+    public ResponseEntity<BulkResultResponse> bulkReject(@RequestBody ReportBulkRequest request) {
+        log.info("[관리자] 신고 선택 반려 - type:{}, count:{}", request.getTargetType(),
+                request.getTargetIds() == null ? 0 : request.getTargetIds().size());
+        BulkResultResponse result = adminReportService.bulkReject(request.getTargetType(), request.getTargetIds());
+        return ResponseEntity.ok(result);
+    }
+
+    // 선택 삭제 (일괄, 부분 성공)
+    @PostMapping("/api/admin/reports/bulk-delete")
+    public ResponseEntity<BulkResultResponse> bulkDelete(@RequestBody ReportBulkRequest request) {
+        log.info("[관리자] 신고 선택 삭제 - type:{}, count:{}", request.getTargetType(),
+                request.getTargetIds() == null ? 0 : request.getTargetIds().size());
+        BulkResultResponse result = adminReportService.bulkDelete(request.getTargetType(), request.getTargetIds());
+        return ResponseEntity.ok(result);
+    }
+}

--- a/src/main/java/com/back/admin/report/dto/AdminReportResponse.java
+++ b/src/main/java/com/back/admin/report/dto/AdminReportResponse.java
@@ -1,0 +1,10 @@
+package com.back.admin.report.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class AdminReportResponse {
+    private String message;
+}

--- a/src/main/java/com/back/admin/report/dto/ReportBulkRequest.java
+++ b/src/main/java/com/back/admin/report/dto/ReportBulkRequest.java
@@ -1,0 +1,13 @@
+package com.back.admin.report.dto;
+
+import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
+
+// 선택 반려 / 선택 삭제 (일괄). targetType 은 현재 활성 탭('post'/'comment').
+@Getter
+@Setter
+public class ReportBulkRequest {
+    private String targetType;
+    private List<Long> targetIds;
+}

--- a/src/main/java/com/back/admin/report/dto/ReportPageResponse.java
+++ b/src/main/java/com/back/admin/report/dto/ReportPageResponse.java
@@ -1,0 +1,14 @@
+package com.back.admin.report.dto;
+
+import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
+
+// 신고 관리 목록 페이지 응답
+@Getter
+@Setter
+public class ReportPageResponse {
+    private int totalPages;
+    private int totalCount;
+    private List<ReportedItemResponse> items;
+}

--- a/src/main/java/com/back/admin/report/dto/ReportStatus.java
+++ b/src/main/java/com/back/admin/report/dto/ReportStatus.java
@@ -1,0 +1,18 @@
+package com.back.admin.report.dto;
+
+// 신고 처리 상태. DB(reports_log.status)에는 소문자 문자열로 저장된다.
+public enum ReportStatus {
+    PENDING("pending"),
+    RESOLVED("resolved"),
+    REJECTED("rejected");
+
+    private final String dbValue;
+
+    ReportStatus(String dbValue) {
+        this.dbValue = dbValue;
+    }
+
+    public String dbValue() {
+        return dbValue;
+    }
+}

--- a/src/main/java/com/back/admin/report/dto/ReportedItemResponse.java
+++ b/src/main/java/com/back/admin/report/dto/ReportedItemResponse.java
@@ -1,0 +1,22 @@
+package com.back.admin.report.dto;
+
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.Setter;
+
+// 신고 관리 목록 한 행 (게시글 신고 / 댓글 신고 공통)
+@Getter
+@Setter
+public class ReportedItemResponse {
+    private String targetType;         // 'post' / 'comment'
+    private Long targetId;             // 신고 대상 post_id / comment_id
+    private String preview;            // 대상 미리보기 (본문 앞부분)
+    private Long boardId;
+    private String boardCode;          // boards.code (댓글은 소속 게시글의 게시판). 한글 표기는 프론트 매핑
+    private String authorName;         // 대상 콘텐츠 작성자
+    private String reasonLabel;        // 대표 신고 사유 (reasons.label)
+    private LocalDateTime firstReportedAt; // 최초 신고일시 = MIN(created_at)
+    private int reportCount;           // 누적 신고 건수
+    private String reportStatus;       // 대표 신고 상태 pending/rejected/resolved
+    private String state;              // 대상의 현재 표시 상태 normal/blind/deleted
+}

--- a/src/main/java/com/back/admin/report/exception/AdminReportException.java
+++ b/src/main/java/com/back/admin/report/exception/AdminReportException.java
@@ -1,0 +1,11 @@
+package com.back.admin.report.exception;
+
+import com.back.global.exception.BaseException;
+import org.springframework.http.HttpStatus;
+
+public class AdminReportException extends BaseException {
+
+    public AdminReportException(String message, HttpStatus status) {
+        super(message, status);
+    }
+}

--- a/src/main/java/com/back/admin/report/mapper/AdminReportMapper.java
+++ b/src/main/java/com/back/admin/report/mapper/AdminReportMapper.java
@@ -1,0 +1,52 @@
+package com.back.admin.report.mapper;
+
+import com.back.admin.report.dto.ReportedItemResponse;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+
+@Mapper
+public interface AdminReportMapper {
+
+    // 신고된 게시글 목록 (대상별 그룹핑, 상태/게시판 필터, 정렬, 페이징)
+    List<ReportedItemResponse> findReportedPosts(
+            @Param("status") String status,
+            @Param("boardId") Long boardId,
+            @Param("sort") String sort,
+            @Param("offset") int offset,
+            @Param("size") int size
+    );
+
+    int countReportedPosts(
+            @Param("status") String status,
+            @Param("boardId") Long boardId
+    );
+
+    // 신고된 댓글 목록
+    List<ReportedItemResponse> findReportedComments(
+            @Param("status") String status,
+            @Param("boardId") Long boardId,
+            @Param("sort") String sort,
+            @Param("offset") int offset,
+            @Param("size") int size
+    );
+
+    int countReportedComments(
+            @Param("status") String status,
+            @Param("boardId") Long boardId
+    );
+
+    // 대상의 대표(최신) 신고 사유 reason_id — 삭제 시 moderation_log 에 기록
+    Long findLatestReasonId(
+            @Param("targetType") String targetType,
+            @Param("targetId") Long targetId
+    );
+
+    // 대상의 pending 신고를 일괄 상태변경 (rejected / resolved). active_flag 는 생성컬럼이라 자동 갱신
+    int updatePendingReportsStatus(
+            @Param("targetType") String targetType,
+            @Param("targetId") Long targetId,
+            @Param("status") String status
+    );
+}

--- a/src/main/java/com/back/admin/report/service/AdminReportService.java
+++ b/src/main/java/com/back/admin/report/service/AdminReportService.java
@@ -1,0 +1,27 @@
+package com.back.admin.report.service;
+
+import com.back.admin.common.dto.BulkResultResponse;
+import com.back.admin.report.dto.ReportPageResponse;
+
+import java.util.List;
+
+public interface AdminReportService {
+
+    // 신고된 게시글 목록
+    ReportPageResponse getReportedPosts(int page, int size, String status, Long boardId, String sort);
+
+    // 신고된 댓글 목록
+    ReportPageResponse getReportedComments(int page, int size, String status, Long boardId, String sort);
+
+    // 반려: 대상 복원(state=normal) + 신고 rejected 처리
+    void reject(String targetType, Long targetId);
+
+    // 삭제: 대상 소프트 삭제(state=deleted, 주의 +2) + 신고 resolved 처리
+    void delete(String targetType, Long targetId);
+
+    // 선택 반려 (일괄, 부분 성공)
+    BulkResultResponse bulkReject(String targetType, List<Long> targetIds);
+
+    // 선택 삭제 (일괄, 부분 성공)
+    BulkResultResponse bulkDelete(String targetType, List<Long> targetIds);
+}

--- a/src/main/java/com/back/admin/report/service/AdminReportServiceImpl.java
+++ b/src/main/java/com/back/admin/report/service/AdminReportServiceImpl.java
@@ -1,19 +1,19 @@
 package com.back.admin.report.service;
 
+import com.back.admin.common.AdminServiceSupport;
 import com.back.admin.common.dto.BulkResultResponse;
 import com.back.admin.report.dto.ReportPageResponse;
 import com.back.admin.report.dto.ReportedItemResponse;
 import com.back.admin.report.exception.AdminReportException;
 import com.back.admin.report.mapper.AdminReportMapper;
-import com.back.global.exception.BaseException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.CollectionUtils;
 
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 
 import static com.back.admin.moderation.service.ModerationServiceImpl.TARGET_COMMENT;
@@ -27,15 +27,6 @@ public class AdminReportServiceImpl implements AdminReportService {
     private final AdminReportMapper adminReportMapper;
     private final ReportBulkExecutor reportBulkExecutor;
 
-    private Long getCurrentAdminId() {
-        String subValue = SecurityContextHolder.getContext().getAuthentication().getName();
-        try {
-            return Long.parseLong(subValue);
-        } catch (NumberFormatException e) {
-            throw new AdminReportException("로그인이 필요한 서비스입니다.", HttpStatus.UNAUTHORIZED);
-        }
-    }
-
     // targetType 검증 (post/comment 만 허용)
     private void validateTargetType(String targetType) {
         if (!TARGET_POST.equals(targetType) && !TARGET_COMMENT.equals(targetType)) {
@@ -45,6 +36,8 @@ public class AdminReportServiceImpl implements AdminReportService {
 
     @Override
     public ReportPageResponse getReportedPosts(int page, int size, String status, Long boardId, String sort) {
+        page = AdminServiceSupport.clampPage(page);
+        size = AdminServiceSupport.clampSize(size);
         int totalCount = adminReportMapper.countReportedPosts(status, boardId);
         int totalPages = (int) Math.ceil((double) totalCount / size);
         int offset = (page - 1) * size;
@@ -54,6 +47,8 @@ public class AdminReportServiceImpl implements AdminReportService {
 
     @Override
     public ReportPageResponse getReportedComments(int page, int size, String status, Long boardId, String sort) {
+        page = AdminServiceSupport.clampPage(page);
+        size = AdminServiceSupport.clampSize(size);
         int totalCount = adminReportMapper.countReportedComments(status, boardId);
         int totalPages = (int) Math.ceil((double) totalCount / size);
         int offset = (page - 1) * size;
@@ -64,15 +59,13 @@ public class AdminReportServiceImpl implements AdminReportService {
     @Override
     public void reject(String targetType, Long targetId) {
         validateTargetType(targetType);
-        Long adminId = getCurrentAdminId();
-        reportBulkExecutor.rejectItem(targetType, targetId, adminId);
+        reportBulkExecutor.rejectItem(targetType, targetId, AdminServiceSupport.currentAdminId());
     }
 
     @Override
     public void delete(String targetType, Long targetId) {
         validateTargetType(targetType);
-        Long adminId = getCurrentAdminId();
-        reportBulkExecutor.deleteItem(targetType, targetId, adminId);
+        reportBulkExecutor.deleteItem(targetType, targetId, AdminServiceSupport.currentAdminId());
     }
 
     @Override
@@ -81,16 +74,16 @@ public class AdminReportServiceImpl implements AdminReportService {
         if (CollectionUtils.isEmpty(targetIds)) {
             throw new AdminReportException("반려할 항목을 선택해 주세요.", HttpStatus.BAD_REQUEST);
         }
-        Long adminId = getCurrentAdminId();
+        Long adminId = AdminServiceSupport.currentAdminId();
 
         int successCount = 0;
         List<BulkResultResponse.FailureItem> failures = new ArrayList<>();
-        for (Long targetId : targetIds) {
+        for (Long targetId : new LinkedHashSet<>(targetIds)) {
             try {
                 reportBulkExecutor.rejectItem(targetType, targetId, adminId);
                 successCount++;
             } catch (Exception e) {
-                failures.add(new BulkResultResponse.FailureItem(targetId, resolveMessage(e)));
+                failures.add(new BulkResultResponse.FailureItem(targetId, AdminServiceSupport.resolveFailureMessage(e)));
             }
         }
         return new BulkResultResponse(successCount, failures);
@@ -102,24 +95,19 @@ public class AdminReportServiceImpl implements AdminReportService {
         if (CollectionUtils.isEmpty(targetIds)) {
             throw new AdminReportException("삭제할 항목을 선택해 주세요.", HttpStatus.BAD_REQUEST);
         }
-        Long adminId = getCurrentAdminId();
+        Long adminId = AdminServiceSupport.currentAdminId();
 
         int successCount = 0;
         List<BulkResultResponse.FailureItem> failures = new ArrayList<>();
-        for (Long targetId : targetIds) {
+        for (Long targetId : new LinkedHashSet<>(targetIds)) {
             try {
                 reportBulkExecutor.deleteItem(targetType, targetId, adminId);
                 successCount++;
             } catch (Exception e) {
-                failures.add(new BulkResultResponse.FailureItem(targetId, resolveMessage(e)));
+                failures.add(new BulkResultResponse.FailureItem(targetId, AdminServiceSupport.resolveFailureMessage(e)));
             }
         }
         return new BulkResultResponse(successCount, failures);
-    }
-
-    // 실패 사유 메시지 추출 (도메인 예외는 그대로, 그 외는 일반 메시지)
-    private String resolveMessage(Exception e) {
-        return (e instanceof BaseException) ? e.getMessage() : "처리 중 오류가 발생했습니다.";
     }
 
     private ReportPageResponse toPage(int totalPages, int totalCount, List<ReportedItemResponse> items) {

--- a/src/main/java/com/back/admin/report/service/AdminReportServiceImpl.java
+++ b/src/main/java/com/back/admin/report/service/AdminReportServiceImpl.java
@@ -1,0 +1,132 @@
+package com.back.admin.report.service;
+
+import com.back.admin.common.dto.BulkResultResponse;
+import com.back.admin.report.dto.ReportPageResponse;
+import com.back.admin.report.dto.ReportedItemResponse;
+import com.back.admin.report.exception.AdminReportException;
+import com.back.admin.report.mapper.AdminReportMapper;
+import com.back.global.exception.BaseException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.CollectionUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.back.admin.moderation.service.ModerationServiceImpl.TARGET_COMMENT;
+import static com.back.admin.moderation.service.ModerationServiceImpl.TARGET_POST;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminReportServiceImpl implements AdminReportService {
+
+    private final AdminReportMapper adminReportMapper;
+    private final ReportBulkExecutor reportBulkExecutor;
+
+    private Long getCurrentAdminId() {
+        String subValue = SecurityContextHolder.getContext().getAuthentication().getName();
+        try {
+            return Long.parseLong(subValue);
+        } catch (NumberFormatException e) {
+            throw new AdminReportException("로그인이 필요한 서비스입니다.", HttpStatus.UNAUTHORIZED);
+        }
+    }
+
+    // targetType 검증 (post/comment 만 허용)
+    private void validateTargetType(String targetType) {
+        if (!TARGET_POST.equals(targetType) && !TARGET_COMMENT.equals(targetType)) {
+            throw new AdminReportException("잘못된 대상 유형입니다: " + targetType, HttpStatus.BAD_REQUEST);
+        }
+    }
+
+    @Override
+    public ReportPageResponse getReportedPosts(int page, int size, String status, Long boardId, String sort) {
+        int totalCount = adminReportMapper.countReportedPosts(status, boardId);
+        int totalPages = (int) Math.ceil((double) totalCount / size);
+        int offset = (page - 1) * size;
+        List<ReportedItemResponse> items = adminReportMapper.findReportedPosts(status, boardId, sort, offset, size);
+        return toPage(totalPages, totalCount, items);
+    }
+
+    @Override
+    public ReportPageResponse getReportedComments(int page, int size, String status, Long boardId, String sort) {
+        int totalCount = adminReportMapper.countReportedComments(status, boardId);
+        int totalPages = (int) Math.ceil((double) totalCount / size);
+        int offset = (page - 1) * size;
+        List<ReportedItemResponse> items = adminReportMapper.findReportedComments(status, boardId, sort, offset, size);
+        return toPage(totalPages, totalCount, items);
+    }
+
+    @Override
+    public void reject(String targetType, Long targetId) {
+        validateTargetType(targetType);
+        Long adminId = getCurrentAdminId();
+        reportBulkExecutor.rejectItem(targetType, targetId, adminId);
+    }
+
+    @Override
+    public void delete(String targetType, Long targetId) {
+        validateTargetType(targetType);
+        Long adminId = getCurrentAdminId();
+        reportBulkExecutor.deleteItem(targetType, targetId, adminId);
+    }
+
+    @Override
+    public BulkResultResponse bulkReject(String targetType, List<Long> targetIds) {
+        validateTargetType(targetType);
+        if (CollectionUtils.isEmpty(targetIds)) {
+            throw new AdminReportException("반려할 항목을 선택해 주세요.", HttpStatus.BAD_REQUEST);
+        }
+        Long adminId = getCurrentAdminId();
+
+        int successCount = 0;
+        List<BulkResultResponse.FailureItem> failures = new ArrayList<>();
+        for (Long targetId : targetIds) {
+            try {
+                reportBulkExecutor.rejectItem(targetType, targetId, adminId);
+                successCount++;
+            } catch (Exception e) {
+                failures.add(new BulkResultResponse.FailureItem(targetId, resolveMessage(e)));
+            }
+        }
+        return new BulkResultResponse(successCount, failures);
+    }
+
+    @Override
+    public BulkResultResponse bulkDelete(String targetType, List<Long> targetIds) {
+        validateTargetType(targetType);
+        if (CollectionUtils.isEmpty(targetIds)) {
+            throw new AdminReportException("삭제할 항목을 선택해 주세요.", HttpStatus.BAD_REQUEST);
+        }
+        Long adminId = getCurrentAdminId();
+
+        int successCount = 0;
+        List<BulkResultResponse.FailureItem> failures = new ArrayList<>();
+        for (Long targetId : targetIds) {
+            try {
+                reportBulkExecutor.deleteItem(targetType, targetId, adminId);
+                successCount++;
+            } catch (Exception e) {
+                failures.add(new BulkResultResponse.FailureItem(targetId, resolveMessage(e)));
+            }
+        }
+        return new BulkResultResponse(successCount, failures);
+    }
+
+    // 실패 사유 메시지 추출 (도메인 예외는 그대로, 그 외는 일반 메시지)
+    private String resolveMessage(Exception e) {
+        return (e instanceof BaseException) ? e.getMessage() : "처리 중 오류가 발생했습니다.";
+    }
+
+    private ReportPageResponse toPage(int totalPages, int totalCount, List<ReportedItemResponse> items) {
+        ReportPageResponse response = new ReportPageResponse();
+        response.setTotalPages(totalPages);
+        response.setTotalCount(totalCount);
+        response.setItems(items);
+        return response;
+    }
+}

--- a/src/main/java/com/back/admin/report/service/ReportBulkExecutor.java
+++ b/src/main/java/com/back/admin/report/service/ReportBulkExecutor.java
@@ -1,0 +1,37 @@
+package com.back.admin.report.service;
+
+import com.back.admin.moderation.service.ModerationService;
+import com.back.admin.report.mapper.AdminReportMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+// 신고 1건 조치(반려/삭제)를 "독립 트랜잭션"으로 실행하는 컴포넌트.
+// 반려/삭제는 (상태 변경 + moderation_log + reports_log 갱신)이 항목 단위로 원자적이어야 하므로
+// REQUIRES_NEW 로 묶는다. 단건/일괄이 모두 이 메서드를 재사용한다.
+@Component
+@RequiredArgsConstructor
+public class ReportBulkExecutor {
+
+    private static final String STATUS_REJECTED = "rejected";
+    private static final String STATUS_RESOLVED = "resolved";
+
+    private final ModerationService moderationService;
+    private final AdminReportMapper adminReportMapper;
+
+    // 반려: 블라인드 → 공개 복원 + 신고 rejected
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void rejectItem(String targetType, Long targetId, Long adminId) {
+        moderationService.restore(targetType, targetId, adminId);
+        adminReportMapper.updatePendingReportsStatus(targetType, targetId, STATUS_REJECTED);
+    }
+
+    // 삭제: 소프트 삭제(주의 +2) + 신고 resolved. 사유는 대표(최신) 신고 사유 사용
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void deleteItem(String targetType, Long targetId, Long adminId) {
+        Long reasonId = adminReportMapper.findLatestReasonId(targetType, targetId);
+        moderationService.softDelete(targetType, targetId, adminId, reasonId, null);
+        adminReportMapper.updatePendingReportsStatus(targetType, targetId, STATUS_RESOLVED);
+    }
+}

--- a/src/main/java/com/back/admin/report/service/ReportBulkExecutor.java
+++ b/src/main/java/com/back/admin/report/service/ReportBulkExecutor.java
@@ -1,6 +1,8 @@
 package com.back.admin.report.service;
 
+import com.back.admin.moderation.dto.ModerationState;
 import com.back.admin.moderation.service.ModerationService;
+import com.back.admin.report.dto.ReportStatus;
 import com.back.admin.report.mapper.AdminReportMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -14,17 +16,17 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class ReportBulkExecutor {
 
-    private static final String STATUS_REJECTED = "rejected";
-    private static final String STATUS_RESOLVED = "resolved";
-
     private final ModerationService moderationService;
     private final AdminReportMapper adminReportMapper;
 
     // 반려: 블라인드 → 공개 복원 + 신고 rejected
+    // 단, 이미 삭제(deleted)된 대상은 되살리지 않는다 (게시글 관리에서 의도적으로 삭제된 콘텐츠·벌점 보호)
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void rejectItem(String targetType, Long targetId, Long adminId) {
-        moderationService.restore(targetType, targetId, adminId);
-        adminReportMapper.updatePendingReportsStatus(targetType, targetId, STATUS_REJECTED);
+        if (!ModerationState.DELETED.dbValue().equals(moderationService.currentState(targetType, targetId))) {
+            moderationService.restore(targetType, targetId, adminId);
+        }
+        adminReportMapper.updatePendingReportsStatus(targetType, targetId, ReportStatus.REJECTED.dbValue());
     }
 
     // 삭제: 소프트 삭제(주의 +2) + 신고 resolved. 사유는 대표(최신) 신고 사유 사용
@@ -32,6 +34,6 @@ public class ReportBulkExecutor {
     public void deleteItem(String targetType, Long targetId, Long adminId) {
         Long reasonId = adminReportMapper.findLatestReasonId(targetType, targetId);
         moderationService.softDelete(targetType, targetId, adminId, reasonId, null);
-        adminReportMapper.updatePendingReportsStatus(targetType, targetId, STATUS_RESOLVED);
+        adminReportMapper.updatePendingReportsStatus(targetType, targetId, ReportStatus.RESOLVED.dbValue());
     }
 }

--- a/src/main/resources/mapper/admin/AdminPostMapper.xml
+++ b/src/main/resources/mapper/admin/AdminPostMapper.xml
@@ -41,4 +41,56 @@
         <include refid="listWhere"/>
     </select>
 
+    <!-- 상세: state 필터 없음 (블라인드/삭제 글도 관리자는 열람 가능) -->
+    <select id="findPostDetail" resultType="com.back.admin.post.dto.AdminPostDetailResponse">
+        SELECT
+            p.post_id      AS postId,
+            p.board_id     AS boardId,
+            b.code         AS boardCode,
+            c.name         AS categoryName,
+            p.title,
+            p.content,
+            p.user_id      AS authorId,
+            u.name         AS authorName,
+            p.is_anonymous AS isAnonymous,
+            p.is_pinned    AS isPinned,
+            p.view_count   AS viewCount,
+            (SELECT COUNT(*) FROM post_likes pl WHERE pl.post_id = p.post_id) AS likeCount,
+            (SELECT COUNT(*) FROM comments cm WHERE cm.post_id = p.post_id) AS commentCount,
+            p.state,
+            p.created_at   AS created,
+            p.updated_at   AS updated
+        FROM posts p
+        INNER JOIN boards b ON p.board_id = b.board_id
+        INNER JOIN users  u ON p.user_id = u.user_id
+        LEFT  JOIN categories c ON p.category_id = c.category_id
+        WHERE p.post_id = #{postId}
+    </select>
+
+    <select id="findAttachments" resultType="com.back.admin.post.dto.AdminAttachmentResponse">
+        SELECT attachment_id AS attachmentId,
+               file_name     AS originName,
+               file_size     AS fileSize,
+               file_url      AS fileUrl
+        FROM attachments
+        WHERE post_id = #{postId}
+    </select>
+
+    <!-- 댓글: state 필터 없음 (블라인드/삭제 댓글까지 관리자에게 노출) -->
+    <select id="findComments" resultType="com.back.admin.post.dto.AdminCommentResponse">
+        SELECT c.comment_id   AS commentId,
+               c.content,
+               c.user_id      AS userId,
+               u.name         AS authorName,
+               c.is_anonymous AS isAnonymous,
+               c.is_private   AS isPrivate,
+               c.state,
+               c.created_at   AS created,
+               c.updated_at   AS updated
+        FROM comments c
+        INNER JOIN users u ON c.user_id = u.user_id
+        WHERE c.post_id = #{postId}
+        ORDER BY c.created_at ASC
+    </select>
+
 </mapper>

--- a/src/main/resources/mapper/admin/AdminPostMapper.xml
+++ b/src/main/resources/mapper/admin/AdminPostMapper.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.back.admin.post.mapper.AdminPostMapper">
+
+    <!-- 공통 WHERE: deleted 제외 + 게시판 필터 + 제목/글쓴이 검색 -->
+    <sql id="listWhere">
+        WHERE p.state &lt;&gt; 'deleted'
+        <if test="boardId != null">
+            AND p.board_id = #{boardId}
+        </if>
+        <if test="keyword != null and keyword != ''">
+            AND (p.title LIKE CONCAT('%', #{keyword}, '%')
+                 OR u.name LIKE CONCAT('%', #{keyword}, '%'))
+        </if>
+    </sql>
+
+    <select id="findPosts" resultType="com.back.admin.post.dto.AdminPostListResponse">
+        SELECT
+            p.post_id AS postId,
+            p.board_id AS boardId,
+            b.code AS boardCode,
+            p.title,
+            u.name AS authorName,
+            (SELECT COUNT(*) FROM comments cm WHERE cm.post_id = p.post_id) AS commentCount,
+            (SELECT COUNT(*) FROM post_likes pl WHERE pl.post_id = p.post_id) AS likeCount,
+            p.view_count AS viewCount,
+            p.created_at AS created,
+            p.state
+        FROM posts p
+        INNER JOIN users u ON p.user_id = u.user_id
+        INNER JOIN boards b ON p.board_id = b.board_id
+        <include refid="listWhere"/>
+        ORDER BY p.created_at DESC
+        LIMIT #{size} OFFSET #{offset}
+    </select>
+
+    <select id="countPosts" resultType="int">
+        SELECT COUNT(*)
+        FROM posts p
+        INNER JOIN users u ON p.user_id = u.user_id
+        <include refid="listWhere"/>
+    </select>
+
+</mapper>

--- a/src/main/resources/mapper/admin/AdminReportMapper.xml
+++ b/src/main/resources/mapper/admin/AdminReportMapper.xml
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.back.admin.report.mapper.AdminReportMapper">
+
+    <!-- ORDER BY 조각 (최신순 기본) -->
+    <sql id="orderBy">
+        ORDER BY
+        <choose>
+            <when test="sort == 'oldest'">t.first_reported_at ASC</when>
+            <otherwise>t.first_reported_at DESC</otherwise>
+        </choose>
+    </sql>
+
+    <!-- ===================== 게시글 신고 ===================== -->
+    <!-- 대상별로 그룹핑: 최초 신고일시/누적건수/대표(최신)신고 -->
+    <sql id="reportedPostsFrom">
+        FROM (
+            SELECT target_id,
+                   MIN(created_at) AS first_reported_at,
+                   COUNT(*)        AS report_count,
+                   MAX(report_id)  AS last_report_id
+            FROM reports_log
+            WHERE target_type = 'post'
+            GROUP BY target_id
+        ) t
+        JOIN reports_log r ON r.report_id = t.last_report_id
+        JOIN posts   p  ON p.post_id = t.target_id
+        JOIN boards  b  ON p.board_id = b.board_id
+        JOIN users   u  ON p.user_id = u.user_id
+        JOIN reasons rs ON r.reason_id = rs.reason_id
+        <where>
+            <if test="status != null and status != ''">AND r.status = #{status}</if>
+            <if test="boardId != null">AND p.board_id = #{boardId}</if>
+        </where>
+    </sql>
+
+    <select id="findReportedPosts" resultType="com.back.admin.report.dto.ReportedItemResponse">
+        SELECT
+            'post'                       AS targetType,
+            t.target_id                  AS targetId,
+            LEFT(p.content, 30)          AS preview,
+            p.board_id                   AS boardId,
+            b.code                       AS boardCode,
+            u.name                       AS authorName,
+            rs.label                     AS reasonLabel,
+            t.first_reported_at          AS firstReportedAt,
+            t.report_count               AS reportCount,
+            r.status                     AS reportStatus,
+            p.state                      AS state
+        <include refid="reportedPostsFrom"/>
+        <include refid="orderBy"/>
+        LIMIT #{size} OFFSET #{offset}
+    </select>
+
+    <select id="countReportedPosts" resultType="int">
+        SELECT COUNT(*)
+        <include refid="reportedPostsFrom"/>
+    </select>
+
+    <!-- ===================== 댓글 신고 ===================== -->
+    <sql id="reportedCommentsFrom">
+        FROM (
+            SELECT target_id,
+                   MIN(created_at) AS first_reported_at,
+                   COUNT(*)        AS report_count,
+                   MAX(report_id)  AS last_report_id
+            FROM reports_log
+            WHERE target_type = 'comment'
+            GROUP BY target_id
+        ) t
+        JOIN reports_log r ON r.report_id = t.last_report_id
+        JOIN comments c ON c.comment_id = t.target_id
+        JOIN posts    p ON c.post_id = p.post_id
+        JOIN boards   b ON p.board_id = b.board_id
+        JOIN users    u ON c.user_id = u.user_id
+        JOIN reasons  rs ON r.reason_id = rs.reason_id
+        <where>
+            <if test="status != null and status != ''">AND r.status = #{status}</if>
+            <if test="boardId != null">AND p.board_id = #{boardId}</if>
+        </where>
+    </sql>
+
+    <select id="findReportedComments" resultType="com.back.admin.report.dto.ReportedItemResponse">
+        SELECT
+            'comment'                    AS targetType,
+            t.target_id                  AS targetId,
+            LEFT(c.content, 30)          AS preview,
+            p.board_id                   AS boardId,
+            b.code                       AS boardCode,
+            u.name                       AS authorName,
+            rs.label                     AS reasonLabel,
+            t.first_reported_at          AS firstReportedAt,
+            t.report_count               AS reportCount,
+            r.status                     AS reportStatus,
+            c.state                      AS state
+        <include refid="reportedCommentsFrom"/>
+        <include refid="orderBy"/>
+        LIMIT #{size} OFFSET #{offset}
+    </select>
+
+    <select id="countReportedComments" resultType="int">
+        SELECT COUNT(*)
+        <include refid="reportedCommentsFrom"/>
+    </select>
+
+    <!-- ===================== 조치 보조 ===================== -->
+    <select id="findLatestReasonId" resultType="long">
+        SELECT reason_id
+        FROM reports_log
+        WHERE target_type = #{targetType}
+          AND target_id = #{targetId}
+        ORDER BY report_id DESC
+        LIMIT 1
+    </select>
+
+    <update id="updatePendingReportsStatus">
+        UPDATE reports_log
+        SET status = #{status}
+        WHERE target_type = #{targetType}
+          AND target_id = #{targetId}
+          AND status = 'pending'
+    </update>
+
+</mapper>

--- a/src/main/resources/mapper/admin/ModerationMapper.xml
+++ b/src/main/resources/mapper/admin/ModerationMapper.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.back.admin.moderation.mapper.ModerationMapper">
+
+    <update id="updatePostState">
+        UPDATE posts
+        SET state = #{state}
+        WHERE post_id = #{postId}
+    </update>
+
+    <update id="updateCommentState">
+        UPDATE comments
+        SET state = #{state}
+        WHERE comment_id = #{commentId}
+    </update>
+
+    <select id="findPostAuthorId" resultType="long">
+        SELECT user_id FROM posts WHERE post_id = #{postId}
+    </select>
+
+    <select id="findCommentAuthorId" resultType="long">
+        SELECT user_id FROM comments WHERE comment_id = #{commentId}
+    </select>
+
+    <insert id="insertModerationLog" useGeneratedKeys="true" keyProperty="entry.actionId">
+        INSERT INTO moderation_log (target_type, target_id, applied_state, reason_id, detail, acted_by, created_at)
+        VALUES (#{entry.targetType}, #{entry.targetId}, #{entry.appliedState},
+                #{entry.reasonId}, #{entry.detail}, #{entry.actedBy}, NOW())
+    </insert>
+
+    <!-- points/시효는 policy_settings 에서 읽고, 없으면 기본값(2/365) 적용 -->
+    <insert id="insertPenalty">
+        INSERT INTO penalty_log (user_id, points, target_type, target_id, source_action_id, created_at, expires_at)
+        SELECT #{userId},
+               CAST(COALESCE((SELECT setting_value FROM policy_settings WHERE code = 'caution_per_delete'), '2') AS SIGNED),
+               #{targetType},
+               #{targetId},
+               #{sourceActionId},
+               NOW(),
+               DATE_ADD(NOW(), INTERVAL CAST(COALESCE((SELECT setting_value FROM policy_settings WHERE code = 'caution_ttl_days'), '365') AS SIGNED) DAY)
+    </insert>
+
+    <!-- 대상에 걸린, 아직 회수되지 않은 주의 포인트를 복원 조치로 void 처리 -->
+    <update id="voidPenaltiesByTarget">
+        UPDATE penalty_log
+        SET voided_at = NOW(),
+            void_action_id = #{voidActionId}
+        WHERE target_type = #{targetType}
+          AND target_id = #{targetId}
+          AND voided_at IS NULL
+    </update>
+
+</mapper>

--- a/src/main/resources/mapper/admin/ModerationMapper.xml
+++ b/src/main/resources/mapper/admin/ModerationMapper.xml
@@ -2,17 +2,28 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.back.admin.moderation.mapper.ModerationMapper">
 
+    <!-- state <> #{state} 조건으로 이미 그 상태면 0건 → 멱등성 + 동시성(행 잠금) 보장 -->
     <update id="updatePostState">
         UPDATE posts
         SET state = #{state}
         WHERE post_id = #{postId}
+          AND state &lt;&gt; #{state}
     </update>
 
     <update id="updateCommentState">
         UPDATE comments
         SET state = #{state}
         WHERE comment_id = #{commentId}
+          AND state &lt;&gt; #{state}
     </update>
+
+    <select id="findPostState" resultType="string">
+        SELECT state FROM posts WHERE post_id = #{postId}
+    </select>
+
+    <select id="findCommentState" resultType="string">
+        SELECT state FROM comments WHERE comment_id = #{commentId}
+    </select>
 
     <select id="findPostAuthorId" resultType="long">
         SELECT user_id FROM posts WHERE post_id = #{postId}

--- a/src/main/resources/mapper/student/FreeMapper.xml
+++ b/src/main/resources/mapper/student/FreeMapper.xml
@@ -15,6 +15,7 @@
                title
         FROM posts
         WHERE board_id = #{boardId}
+          AND state = 'normal'
         ORDER BY created_at DESC
             LIMIT 5
     </select>
@@ -35,6 +36,7 @@
         INNER JOIN users u ON p.user_id = u.user_id
         LEFT JOIN categories c ON p.category_id = c.category_id
         WHERE p.board_id = #{boardId}
+          AND p.state = 'normal'
         <if test="categoryId != null">
             AND p.category_id = #{categoryId}
         </if>
@@ -53,6 +55,7 @@
         SELECT COUNT(*)
         FROM posts
         WHERE board_id = #{boardId}
+          AND state = 'normal'
         <if test="categoryId != null">
             AND category_id = #{categoryId}
         </if>
@@ -82,17 +85,17 @@
         <choose>
             <when test="sort == 'viewCount'">
                 (SELECT post_id FROM posts
-                WHERE board_id = #{boardId} AND post_id != p.post_id
+                WHERE board_id = #{boardId} AND state = 'normal' AND post_id != p.post_id
                 AND (view_count &gt; p.view_count OR (view_count = p.view_count AND post_id &gt; p.post_id))
                 ORDER BY view_count ASC, post_id ASC LIMIT 1) AS prevPostApi,
                 (SELECT post_id FROM posts
-                WHERE board_id = #{boardId} AND post_id != p.post_id
+                WHERE board_id = #{boardId} AND state = 'normal' AND post_id != p.post_id
                 AND (view_count &lt; p.view_count OR (view_count = p.view_count AND post_id &lt; p.post_id))
                 ORDER BY view_count DESC, post_id DESC LIMIT 1) AS nextPostApi
             </when>
             <otherwise>
-                (SELECT MAX(post_id) FROM posts WHERE board_id = #{boardId} AND post_id &lt; #{postId}) AS prevPostApi,
-                (SELECT MIN(post_id) FROM posts WHERE board_id = #{boardId} AND post_id &gt; #{postId}) AS nextPostApi
+                (SELECT MAX(post_id) FROM posts WHERE board_id = #{boardId} AND state = 'normal' AND post_id &lt; #{postId}) AS prevPostApi,
+                (SELECT MIN(post_id) FROM posts WHERE board_id = #{boardId} AND state = 'normal' AND post_id &gt; #{postId}) AS nextPostApi
             </otherwise>
         </choose>
         FROM posts p
@@ -100,6 +103,7 @@
         LEFT JOIN categories ct ON p.category_id = ct.category_id
         WHERE p.post_id = #{postId}
         AND p.board_id = #{boardId}
+        AND p.state = 'normal'
     </select>
 
     <select id="findAttachmentsByPostId" resultType="com.back.student.free.dto.AttachmentFileResponse">
@@ -123,6 +127,7 @@
         FROM comments c
                  JOIN users u ON c.user_id = u.user_id
         WHERE c.post_id = #{postId}
+          AND c.state = 'normal'
         ORDER BY c.created_at ASC
     </select>
 

--- a/src/main/resources/mapper/student/FreeMapper.xml
+++ b/src/main/resources/mapper/student/FreeMapper.xml
@@ -30,7 +30,7 @@
         p.created_at AS created,
         c.name AS categoryName,
         EXISTS (SELECT 1 FROM attachments a WHERE a.post_id = p.post_id) AS hasAttachment,
-        (SELECT COUNT(*) FROM comments cm WHERE cm.post_id = p.post_id) AS commentCount,
+        (SELECT COUNT(*) FROM comments cm WHERE cm.post_id = p.post_id AND cm.state = 'normal') AS commentCount,
         (SELECT COUNT(*) FROM post_likes pl WHERE pl.post_id = p.post_id) AS likeCount
         FROM posts p
         INNER JOIN users u ON p.user_id = u.user_id
@@ -183,11 +183,12 @@
         WHERE post_id = #{postId}
     </update>
 
-    <delete id="deletePost">
-        DELETE
-        FROM posts
+    <!-- 학생 본인 삭제도 소프트 삭제(state=deleted)로 통일. 물리 삭제하지 않음 -->
+    <update id="deletePost">
+        UPDATE posts
+        SET state = 'deleted'
         WHERE post_id = #{postId}
-    </delete>
+    </update>
 
     <insert id="insertComment">
         INSERT INTO comments (post_id, user_id, content, is_anonymous, created_at)
@@ -206,8 +207,11 @@
         WHERE comment_id = #{commentId}
     </update>
 
-    <delete id="deleteComment">
-        DELETE FROM comments WHERE comment_id = #{commentId}
-    </delete>
+    <!-- 학생 본인 댓글 삭제도 소프트 삭제로 통일 -->
+    <update id="deleteComment">
+        UPDATE comments
+        SET state = 'deleted'
+        WHERE comment_id = #{commentId}
+    </update>
 
 </mapper>

--- a/src/main/resources/mapper/student/InfoMapper.xml
+++ b/src/main/resources/mapper/student/InfoMapper.xml
@@ -15,6 +15,7 @@
                title
         FROM posts
         WHERE board_id = #{boardId}
+          AND state = 'normal'
         ORDER BY created_at DESC
             LIMIT 5
     </select>
@@ -34,6 +35,7 @@
         INNER JOIN users u ON p.user_id = u.user_id
         LEFT JOIN categories c ON p.category_id = c.category_id
         WHERE p.board_id = #{boardId}
+          AND p.state = 'normal'
         <if test="categoryId != null">
             AND p.category_id = #{categoryId}
         </if>
@@ -52,6 +54,7 @@
         SELECT COUNT(*)
         FROM posts
         WHERE board_id = #{boardId}
+          AND state = 'normal'
         <if test="categoryId != null">
             AND category_id = #{categoryId}
         </if>
@@ -79,17 +82,17 @@
         <choose>
             <when test="sort == 'viewCount'">
                 (SELECT post_id FROM posts
-                WHERE board_id = #{boardId} AND post_id != p.post_id
+                WHERE board_id = #{boardId} AND state = 'normal' AND post_id != p.post_id
                 AND (view_count &gt; p.view_count OR (view_count = p.view_count AND post_id &gt; p.post_id))
                 ORDER BY view_count ASC, post_id ASC LIMIT 1) AS prevPostApi,
                 (SELECT post_id FROM posts
-                WHERE board_id = #{boardId} AND post_id != p.post_id
+                WHERE board_id = #{boardId} AND state = 'normal' AND post_id != p.post_id
                 AND (view_count &lt; p.view_count OR (view_count = p.view_count AND post_id &lt; p.post_id))
                 ORDER BY view_count DESC, post_id DESC LIMIT 1) AS nextPostApi
             </when>
             <otherwise>
-                (SELECT MAX(post_id) FROM posts WHERE board_id = #{boardId} AND post_id &lt; #{postId}) AS prevPostApi,
-                (SELECT MIN(post_id) FROM posts WHERE board_id = #{boardId} AND post_id &gt; #{postId}) AS nextPostApi
+                (SELECT MAX(post_id) FROM posts WHERE board_id = #{boardId} AND state = 'normal' AND post_id &lt; #{postId}) AS prevPostApi,
+                (SELECT MIN(post_id) FROM posts WHERE board_id = #{boardId} AND state = 'normal' AND post_id &gt; #{postId}) AS nextPostApi
             </otherwise>
         </choose>
         FROM posts p
@@ -97,6 +100,7 @@
         LEFT JOIN categories ct ON p.category_id = ct.category_id
         WHERE p.post_id = #{postId}
         AND p.board_id = #{boardId}
+        AND p.state = 'normal'
     </select>
 
     <select id="findAttachmentsByPostId" resultType="com.back.student.info.dto.AttachmentFileResponse">
@@ -119,6 +123,7 @@
         FROM comments c
                  JOIN users u ON c.user_id = u.user_id
         WHERE c.post_id = #{postId}
+          AND c.state = 'normal'
         ORDER BY c.created_at ASC
     </select>
 

--- a/src/main/resources/mapper/student/InfoMapper.xml
+++ b/src/main/resources/mapper/student/InfoMapper.xml
@@ -29,7 +29,7 @@
         p.created_at AS created,
         c.name AS categoryName,
         EXISTS (SELECT 1 FROM attachments a WHERE a.post_id = p.post_id) AS hasAttachment,
-        (SELECT COUNT(*) FROM comments cm WHERE cm.post_id = p.post_id) AS commentCount,
+        (SELECT COUNT(*) FROM comments cm WHERE cm.post_id = p.post_id AND cm.state = 'normal') AS commentCount,
         (SELECT COUNT(*) FROM post_likes pl WHERE pl.post_id = p.post_id) AS likeCount
         FROM posts p
         INNER JOIN users u ON p.user_id = u.user_id
@@ -178,11 +178,12 @@
         WHERE post_id = #{postId}
     </update>
 
-    <delete id="deletePost">
-        DELETE
-        FROM posts
+    <!-- 학생 본인 삭제도 소프트 삭제(state=deleted)로 통일. 물리 삭제하지 않음 -->
+    <update id="deletePost">
+        UPDATE posts
+        SET state = 'deleted'
         WHERE post_id = #{postId}
-    </delete>
+    </update>
 
     <insert id="insertComment">
         INSERT INTO comments (post_id, user_id, content, is_private, created_at)
@@ -201,8 +202,11 @@
         WHERE comment_id = #{commentId}
     </update>
 
-    <delete id="deleteComment">
-        DELETE FROM comments WHERE comment_id = #{commentId}
-    </delete>
+    <!-- 학생 본인 댓글 삭제도 소프트 삭제로 통일 -->
+    <update id="deleteComment">
+        UPDATE comments
+        SET state = 'deleted'
+        WHERE comment_id = #{commentId}
+    </update>
 
 </mapper>

--- a/src/main/resources/mapper/student/NoticeMapper.xml
+++ b/src/main/resources/mapper/student/NoticeMapper.xml
@@ -16,6 +16,7 @@
         FROM posts p
         INNER JOIN users u ON p.user_id = u.user_id
         WHERE p.board_id = #{boardId}
+          AND p.state = 'normal'
         <if test="keyword != null and keyword != ''">
             AND (p.title LIKE CONCAT('%', #{keyword}, '%') OR p.content LIKE CONCAT('%', #{keyword}, '%'))
         </if>
@@ -32,6 +33,7 @@
         SELECT COUNT(*)
         FROM posts
         WHERE board_id = #{boardId}
+          AND state = 'normal'
         <if test="keyword != null and keyword != ''">
             AND (title LIKE CONCAT('%', #{keyword}, '%') OR content LIKE CONCAT('%', #{keyword}, '%'))
         </if>
@@ -43,6 +45,7 @@
                is_pinned AS isPinned
         FROM posts
         WHERE board_id = #{boardId}
+          AND state = 'normal'
         ORDER BY is_pinned DESC, created_at DESC
             LIMIT 5
     </select>
@@ -67,24 +70,25 @@
             <when test="sort == 'viewCount'">
                 -- 이전글: 현재 글(p)의 view_count보다 크거나, 같으면서 ID가 큰 글 조회
                 (SELECT post_id FROM posts
-                WHERE board_id = #{boardId} AND post_id != p.post_id
+                WHERE board_id = #{boardId} AND state = 'normal' AND post_id != p.post_id
                 AND (view_count &gt; p.view_count OR (view_count = p.view_count AND post_id &gt; p.post_id))
                 ORDER BY view_count ASC, post_id ASC LIMIT 1) AS prevPostApi,
                 -- 다음글: 현재 글(p)의 view_count보다 작거나, 같으면서 ID가 작은 글 조회
                 (SELECT post_id FROM posts
-                WHERE board_id = #{boardId} AND post_id != p.post_id
+                WHERE board_id = #{boardId} AND state = 'normal' AND post_id != p.post_id
                 AND (view_count &lt; p.view_count OR (view_count = p.view_count AND post_id &lt; p.post_id))
                 ORDER BY view_count DESC, post_id DESC LIMIT 1) AS nextPostApi
             </when>
             <otherwise>
-                (SELECT MAX(post_id) FROM posts WHERE board_id = #{boardId} AND post_id &lt; #{postId}) AS prevPostApi,
-                (SELECT MIN(post_id) FROM posts WHERE board_id = #{boardId} AND post_id &gt; #{postId}) AS nextPostApi
+                (SELECT MAX(post_id) FROM posts WHERE board_id = #{boardId} AND state = 'normal' AND post_id &lt; #{postId}) AS prevPostApi,
+                (SELECT MIN(post_id) FROM posts WHERE board_id = #{boardId} AND state = 'normal' AND post_id &gt; #{postId}) AS nextPostApi
             </otherwise>
         </choose>
         FROM posts p
         JOIN users u ON p.user_id = u.user_id
         WHERE p.post_id = #{postId}
         AND p.board_id = #{boardId}
+        AND p.state = 'normal'
     </select>
 
     <select id="findAttachmentIdsByPostId" resultType="com.back.student.notice.dto.AttachmentFileResponse">


### PR DESCRIPTION
## Explain this Pull Request 🙏

- ✨ [BE] 관리자 커뮤니티 관리(게시글/신고) 기능 추가

## What has changed? 🤔

- **게시글 관리**: 전체 목록 조회(최신순·게시판/키워드 검색·페이징), 블라인드/공개/삭제(soft) 처리
- **신고 관리**: 게시글/댓글 신고 목록(그룹핑·상태필터·정렬), 반려/삭제, 선택 일괄 처리(부분 성공)
- **공통 조치 모듈(moderation)**: `state` 변경 + `moderation_log` 기록 + 삭제 시 `penalty_log`(+2) 부여 / 복원 시 회수
- 게시판명은 `boards` 테이블 기반(`code`)으로 반환
- 기존 자유/정보/공지 조회 쿼리에 `state='normal'` 필터 추가 → 블라인드/삭제 콘텐츠 숨김
- admin `post` / `report` / `moderation` 도메인 신규 추가 (Controller · Service · Mapper · DTO)

## Document🗒️ (Optional)

## Screenshot 📸 (Optional)
