### PR TITLE
[BE] 회원 목록 조회 기능 추가 - 검색/정렬/페이지네이션

### DIFF
--- a/src/main/java/com/back/member/controller/MemberController.java
+++ b/src/main/java/com/back/member/controller/MemberController.java
@@ -1,7 +1,9 @@
 package com.back.member.controller;
 
+import com.back.member.dto.MemberBanRequest;
 import com.back.member.dto.MemberPageResponse;
 import com.back.member.dto.MemberResponse;
+import com.back.member.dto.MemberSuspendRequest;
 import com.back.member.dto.MemberUpdateRequest;
 import com.back.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
@@ -9,6 +11,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -41,5 +44,21 @@ public class MemberController {
             @RequestBody MemberUpdateRequest request) {
         log.info("회원 정보 수정 요청 - userId: {}, 데이터: {}", userId, request);
         return ResponseEntity.ok(memberService.updateMember(userId, request));
+    }
+
+    // 회원 정지 (temporary) - 단일 회원, 종료일까지 - 관리자 전용
+    @PostMapping("/api/admin/members/{userId}/suspend")
+    public ResponseEntity<MemberResponse> suspendMember(
+            @PathVariable Long userId,
+            @RequestBody MemberSuspendRequest request) {
+        log.info("회원 정지 요청 - userId: {}, 데이터: {}", userId, request);
+        return ResponseEntity.ok(memberService.suspendMember(userId, request));
+    }
+
+    // 회원 영구차단 (permanent) - 단일/다중 회원 - 관리자 전용
+    @PostMapping("/api/admin/members/ban")
+    public ResponseEntity<MemberResponse> banMembers(@RequestBody MemberBanRequest request) {
+        log.info("회원 영구차단 요청 - 데이터: {}", request);
+        return ResponseEntity.ok(memberService.banMembers(request));
     }
 }

--- a/src/main/java/com/back/member/controller/MemberController.java
+++ b/src/main/java/com/back/member/controller/MemberController.java
@@ -1,11 +1,16 @@
 package com.back.member.controller;
 
 import com.back.member.dto.MemberPageResponse;
+import com.back.member.dto.MemberResponse;
+import com.back.member.dto.MemberUpdateRequest;
 import com.back.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -27,5 +32,14 @@ public class MemberController {
         MemberPageResponse response = memberService.getMembers(page, size, keyword, sort);
         log.info("회원 목록 조회 성공 - 총 {}명, 현재 페이지 {}건", response.getTotalCount(), response.getMembers().size());
         return ResponseEntity.ok(response);
+    }
+
+    // 회원 정보 수정 (이름/전화/학번/이메일 + 재학상태/권한) - 관리자 전용
+    @PutMapping("/api/admin/members/{userId}")
+    public ResponseEntity<MemberResponse> updateMember(
+            @PathVariable Long userId,
+            @RequestBody MemberUpdateRequest request) {
+        log.info("회원 정보 수정 요청 - userId: {}, 데이터: {}", userId, request);
+        return ResponseEntity.ok(memberService.updateMember(userId, request));
     }
 }

--- a/src/main/java/com/back/member/controller/MemberController.java
+++ b/src/main/java/com/back/member/controller/MemberController.java
@@ -1,0 +1,31 @@
+package com.back.member.controller;
+
+import com.back.member.dto.MemberPageResponse;
+import com.back.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class MemberController {
+
+    private final MemberService memberService;
+
+    // 회원 전체 목록 조회 (검색, 정렬, 페이지네이션) - 관리자 전용
+    @GetMapping("/api/admin/members")
+    public ResponseEntity<MemberPageResponse> getMembers(
+            @RequestParam(value = "page", defaultValue = "1") int page,
+            @RequestParam(value = "size", defaultValue = "10") int size,
+            @RequestParam(value = "keyword", required = false) String keyword,
+            @RequestParam(value = "sort", defaultValue = "latest") String sort) {
+        log.info("회원 목록 조회 요청 - page: {}, size: {}, keyword: {}, sort: {}", page, size, keyword, sort);
+        MemberPageResponse response = memberService.getMembers(page, size, keyword, sort);
+        log.info("회원 목록 조회 성공 - 총 {}명, 현재 페이지 {}건", response.getTotalCount(), response.getMembers().size());
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/back/member/dto/MemberBanRequest.java
+++ b/src/main/java/com/back/member/dto/MemberBanRequest.java
@@ -1,0 +1,15 @@
+package com.back.member.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.util.List;
+
+// 회원 영구차단(permanent) 요청 - 단일 또는 다중 회원
+@Getter
+@Setter
+@ToString
+public class MemberBanRequest {
+    private List<Long> userIds;
+}

--- a/src/main/java/com/back/member/dto/MemberListResponse.java
+++ b/src/main/java/com/back/member/dto/MemberListResponse.java
@@ -1,0 +1,33 @@
+package com.back.member.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+// 회원 목록 - 행 단위 응답 DTO
+@Getter
+@Setter
+public class MemberListResponse {
+
+    // [화면에 보여지지 않지만 꼭 가져와야 하는 것] 회원 선택/정지/차단 대상 식별용
+    private Long userId;
+
+    // [화면 표시] 검색 결과 컬럼
+    private String loginId;      // ID (예: CH400)
+    private String name;         // 이름
+    private String phone;        // 전화번호
+    private String studentNo;    // 학번
+    private String email;        // Email
+    private Integer status;      // 재학상태 (0: 재학 / 1: 휴학 / 2: 졸업)
+    private String role;         // 권한 (ADMIN / STUDENTS / ALUMNI)
+    private int postCount;       // 게시글 수
+    private int commentCount;    // 댓글 수
+
+    // 정지 기간 (현재 유효한 차단 1건 기준) - 차단 없으면 null → 화면에서 "-"
+    private LocalDateTime banStartAt;  // 정지 시작 (ban_log.starts_at)
+    private LocalDateTime banEndAt;    // 정지 종료 (ban_log.ends_at, 영구차단이면 null)
+
+    // [화면에 보여지지 않지만 꼭 가져와야 하는 것] 차단 상태 캐시 (none / temporary / permanent)
+    private String banStatus;
+}

--- a/src/main/java/com/back/member/dto/MemberPageResponse.java
+++ b/src/main/java/com/back/member/dto/MemberPageResponse.java
@@ -1,0 +1,15 @@
+package com.back.member.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+// 회원 목록 전체 조회 - 페이지 응답 (페이지 넘기기용 메타 포함)
+@Getter
+@Setter
+public class MemberPageResponse {
+    private int totalPages;   // 전체 페이지 수
+    private long totalCount;  // 전체 회원 수(검색 조건 반영)
+    private List<MemberListResponse> members;
+}

--- a/src/main/java/com/back/member/dto/MemberResponse.java
+++ b/src/main/java/com/back/member/dto/MemberResponse.java
@@ -1,0 +1,12 @@
+package com.back.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+// 회원 관리 작업(수정 등) 공통 응답
+@Getter
+@AllArgsConstructor
+public class MemberResponse {
+    private String message;
+    private Long userId;
+}

--- a/src/main/java/com/back/member/dto/MemberSuspendRequest.java
+++ b/src/main/java/com/back/member/dto/MemberSuspendRequest.java
@@ -1,0 +1,16 @@
+package com.back.member.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.time.LocalDate;
+
+// 회원 정지(temporary) 요청 - 단일 회원
+// endDate: 정지 완료일(ISO yyyy-MM-dd). 시작은 지금(now), 종료는 이 날짜의 하루 끝.
+@Getter
+@Setter
+@ToString
+public class MemberSuspendRequest {
+    private LocalDate endDate;
+}

--- a/src/main/java/com/back/member/dto/MemberUpdateRequest.java
+++ b/src/main/java/com/back/member/dto/MemberUpdateRequest.java
@@ -1,0 +1,21 @@
+package com.back.member.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+// 회원 정보 수정 요청 (부분 수정)
+// - 이름/전화/학번/이메일 : 더블클릭 인라인 수정
+// - status/role          : 재학상태/권한 선택 수정
+// 모든 필드 nullable → 전달된(non-null) 필드만 검증 후 수정
+@Getter
+@Setter
+@ToString
+public class MemberUpdateRequest {
+    private String name;        // 이름 (문자만)
+    private String phone;       // 전화번호 (8자리, 4-4)
+    private String studentNo;   // 학번 (10자리 숫자)
+    private String email;       // 이메일 (이메일 형식)
+    private Integer status;     // 재학상태 (0: 재학 / 1: 휴학 / 2: 졸업)
+    private String role;        // 권한 (ADMIN / STUDENTS / ALUMNI)
+}

--- a/src/main/java/com/back/member/exception/MemberException.java
+++ b/src/main/java/com/back/member/exception/MemberException.java
@@ -1,0 +1,11 @@
+package com.back.member.exception;
+
+import com.back.global.exception.BaseException;
+import org.springframework.http.HttpStatus;
+
+public class MemberException extends BaseException {
+
+    public MemberException(String message, HttpStatus status) {
+        super(message, status);
+    }
+}

--- a/src/main/java/com/back/member/mapper/MemberMapper.java
+++ b/src/main/java/com/back/member/mapper/MemberMapper.java
@@ -1,0 +1,22 @@
+package com.back.member.mapper;
+
+import com.back.member.dto.MemberListResponse;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+
+@Mapper
+public interface MemberMapper {
+
+    // 회원 전체 목록 조회 (검색, 정렬, 페이지네이션 포함)
+    List<MemberListResponse> findMembers(
+            @Param("keyword") String keyword,
+            @Param("sort") String sort,
+            @Param("offset") int offset,
+            @Param("size") int size
+    );
+
+    // 회원 총 개수 조회 (페이지 계산용, 검색 조건 반영)
+    long countMembers(@Param("keyword") String keyword);
+}

--- a/src/main/java/com/back/member/mapper/MemberMapper.java
+++ b/src/main/java/com/back/member/mapper/MemberMapper.java
@@ -5,6 +5,7 @@ import com.back.member.dto.MemberUpdateRequest;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Mapper
@@ -35,4 +36,20 @@ public interface MemberMapper {
 
     // 회원 정보 수정 (전달된 필드만 동적 수정)
     int updateMember(@Param("userId") Long userId, @Param("req") MemberUpdateRequest req);
+
+    // 차단 이력 기록 (정지/영구차단 공통). endsAt = null 이면 영구
+    void insertBanLog(
+            @Param("userId") Long userId,
+            @Param("warningNo") int warningNo,
+            @Param("banType") String banType,
+            @Param("startsAt") LocalDateTime startsAt,
+            @Param("endsAt") LocalDateTime endsAt
+    );
+
+    // users 차단 상태 캐시 갱신. bannedUntil = null 이면 영구(none 해제 포함 재사용 가능)
+    void updateUserBanStatus(
+            @Param("userId") Long userId,
+            @Param("banStatus") String banStatus,
+            @Param("bannedUntil") LocalDateTime bannedUntil
+    );
 }

--- a/src/main/java/com/back/member/mapper/MemberMapper.java
+++ b/src/main/java/com/back/member/mapper/MemberMapper.java
@@ -28,8 +28,8 @@ public interface MemberMapper {
     // 이메일 중복 확인 (본인 제외) - uq_users_email
     boolean existsEmailExcludingUser(@Param("email") String email, @Param("userId") Long userId);
 
-    // 전화번호 중복 확인 (본인 제외) - uq_users_phone
-    boolean existsPhoneExcludingUser(@Param("phone") String phone, @Param("userId") Long userId);
+    // 전화번호 중복 확인 (본인 제외) - uq_users_phone. 저장된 값의 하이픈을 제거한 숫자끼리 비교
+    boolean existsPhoneDigitsExcludingUser(@Param("phoneDigits") String phoneDigits, @Param("userId") Long userId);
 
     // 학번 중복 확인 (본인 제외) - uq_users_student_no
     boolean existsStudentNoExcludingUser(@Param("studentNo") String studentNo, @Param("userId") Long userId);
@@ -37,7 +37,10 @@ public interface MemberMapper {
     // 회원 정보 수정 (전달된 필드만 동적 수정)
     int updateMember(@Param("userId") Long userId, @Param("req") MemberUpdateRequest req);
 
-    // 차단 이력 기록 (정지/영구차단 공통). endsAt = null 이면 영구
+    // 현재 차단 상태 캐시 조회 (none / temporary / permanent) - 정지 전 영구차단 여부 확인용
+    String findBanStatus(@Param("userId") Long userId);
+
+    // 차단 이력 기록 (단일 - 정지용). endsAt = null 이면 영구
     void insertBanLog(
             @Param("userId") Long userId,
             @Param("warningNo") int warningNo,
@@ -46,9 +49,28 @@ public interface MemberMapper {
             @Param("endsAt") LocalDateTime endsAt
     );
 
-    // users 차단 상태 캐시 갱신. bannedUntil = null 이면 영구(none 해제 포함 재사용 가능)
+    // users 차단 상태 캐시 갱신 (단일 - 정지용). bannedUntil = null 이면 영구
     void updateUserBanStatus(
             @Param("userId") Long userId,
+            @Param("banStatus") String banStatus,
+            @Param("bannedUntil") LocalDateTime bannedUntil
+    );
+
+    // 주어진 id 중 실제 존재하는(미탈퇴) 회원 id 목록 - 영구차단 대상 일괄 검증용
+    List<Long> findActiveMemberIds(@Param("ids") List<Long> ids);
+
+    // 차단 이력 일괄 기록 (영구차단용 - 여러 회원, 공통 startsAt/banType/warningNo)
+    void insertBanLogBatch(
+            @Param("userIds") List<Long> userIds,
+            @Param("warningNo") int warningNo,
+            @Param("banType") String banType,
+            @Param("startsAt") LocalDateTime startsAt,
+            @Param("endsAt") LocalDateTime endsAt
+    );
+
+    // users 차단 상태 캐시 일괄 갱신 (영구차단용 - 여러 회원)
+    void updateUserBanStatusByIds(
+            @Param("userIds") List<Long> userIds,
             @Param("banStatus") String banStatus,
             @Param("bannedUntil") LocalDateTime bannedUntil
     );

--- a/src/main/java/com/back/member/mapper/MemberMapper.java
+++ b/src/main/java/com/back/member/mapper/MemberMapper.java
@@ -1,6 +1,7 @@
 package com.back.member.mapper;
 
 import com.back.member.dto.MemberListResponse;
+import com.back.member.dto.MemberUpdateRequest;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
@@ -19,4 +20,19 @@ public interface MemberMapper {
 
     // 회원 총 개수 조회 (페이지 계산용, 검색 조건 반영)
     long countMembers(@Param("keyword") String keyword);
+
+    // 활성(미탈퇴) 회원 존재 여부 - 수정 대상 확인용
+    boolean existsActiveMember(@Param("userId") Long userId);
+
+    // 이메일 중복 확인 (본인 제외) - uq_users_email
+    boolean existsEmailExcludingUser(@Param("email") String email, @Param("userId") Long userId);
+
+    // 전화번호 중복 확인 (본인 제외) - uq_users_phone
+    boolean existsPhoneExcludingUser(@Param("phone") String phone, @Param("userId") Long userId);
+
+    // 학번 중복 확인 (본인 제외) - uq_users_student_no
+    boolean existsStudentNoExcludingUser(@Param("studentNo") String studentNo, @Param("userId") Long userId);
+
+    // 회원 정보 수정 (전달된 필드만 동적 수정)
+    int updateMember(@Param("userId") Long userId, @Param("req") MemberUpdateRequest req);
 }

--- a/src/main/java/com/back/member/service/MemberService.java
+++ b/src/main/java/com/back/member/service/MemberService.java
@@ -1,9 +1,14 @@
 package com.back.member.service;
 
 import com.back.member.dto.MemberPageResponse;
+import com.back.member.dto.MemberResponse;
+import com.back.member.dto.MemberUpdateRequest;
 
 public interface MemberService {
 
     // 회원 전체 목록 조회 (검색, 정렬, 페이지네이션)
     MemberPageResponse getMembers(int page, int size, String keyword, String sort);
+
+    // 회원 정보 수정 (이름/전화/학번/이메일/재학상태/권한)
+    MemberResponse updateMember(Long userId, MemberUpdateRequest request);
 }

--- a/src/main/java/com/back/member/service/MemberService.java
+++ b/src/main/java/com/back/member/service/MemberService.java
@@ -1,7 +1,9 @@
 package com.back.member.service;
 
+import com.back.member.dto.MemberBanRequest;
 import com.back.member.dto.MemberPageResponse;
 import com.back.member.dto.MemberResponse;
+import com.back.member.dto.MemberSuspendRequest;
 import com.back.member.dto.MemberUpdateRequest;
 
 public interface MemberService {
@@ -11,4 +13,10 @@ public interface MemberService {
 
     // 회원 정보 수정 (이름/전화/학번/이메일/재학상태/권한)
     MemberResponse updateMember(Long userId, MemberUpdateRequest request);
+
+    // 회원 정지 (temporary) - 단일 회원, 종료일까지
+    MemberResponse suspendMember(Long userId, MemberSuspendRequest request);
+
+    // 회원 영구차단 (permanent) - 단일 또는 다중 회원
+    MemberResponse banMembers(MemberBanRequest request);
 }

--- a/src/main/java/com/back/member/service/MemberService.java
+++ b/src/main/java/com/back/member/service/MemberService.java
@@ -1,0 +1,9 @@
+package com.back.member.service;
+
+import com.back.member.dto.MemberPageResponse;
+
+public interface MemberService {
+
+    // 회원 전체 목록 조회 (검색, 정렬, 페이지네이션)
+    MemberPageResponse getMembers(int page, int size, String keyword, String sort);
+}

--- a/src/main/java/com/back/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/back/member/service/MemberServiceImpl.java
@@ -2,6 +2,8 @@ package com.back.member.service;
 
 import com.back.member.dto.MemberListResponse;
 import com.back.member.dto.MemberPageResponse;
+import com.back.member.dto.MemberResponse;
+import com.back.member.dto.MemberUpdateRequest;
 import com.back.member.exception.MemberException;
 import com.back.member.mapper.MemberMapper;
 import lombok.RequiredArgsConstructor;
@@ -12,6 +14,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
 
 @Slf4j
 @Service
@@ -20,6 +24,20 @@ import java.util.List;
 public class MemberServiceImpl implements MemberService {
 
     private final MemberMapper memberMapper;
+
+    // ===== 회원 정보 수정 검증 규칙 =====
+    // 이름: 한글/영문 문자만 (숫자·특수문자 불가), 공백 허용
+    private static final Pattern NAME_PATTERN = Pattern.compile("^[가-힣a-zA-Z\\s]+$");
+    // 전화번호: 숫자 8자리 (하이픈 제거 후 검증)
+    private static final Pattern PHONE_DIGITS_PATTERN = Pattern.compile("^\\d{8}$");
+    // 학번: 숫자 10자리
+    private static final Pattern STUDENT_NO_PATTERN = Pattern.compile("^\\d{10}$");
+    // 이메일 형식
+    private static final Pattern EMAIL_PATTERN = Pattern.compile("^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$");
+    // 재학상태: 0(재학) / 1(휴학) / 2(졸업)
+    private static final Set<Integer> ALLOWED_STATUS = Set.of(0, 1, 2);
+    // 권한: DB에 저장되는 실제 role 값 (관리 Lv 체계는 추후 확장)
+    private static final Set<String> ALLOWED_ROLES = Set.of("ADMIN", "STUDENTS", "ALUMNI");
 
     // 관리자 권한 확인 (경로는 SecurityConfig에서 이미 ADMIN 제한, 방어적으로 한 번 더 확인)
     private void checkAdminRole() {
@@ -54,5 +72,84 @@ public class MemberServiceImpl implements MemberService {
         response.setTotalCount(totalCount);
         response.setMembers(members);
         return response;
+    }
+
+    @Override
+    @Transactional
+    public MemberResponse updateMember(Long userId, MemberUpdateRequest request) {
+        checkAdminRole();
+
+        // 수정 대상(활성 회원) 존재 확인
+        if (!memberMapper.existsActiveMember(userId)) {
+            throw new MemberException("해당 회원을 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+        }
+
+        // 전달된 필드만 검증 (부분 수정). 아무 필드도 없으면 잘못된 요청
+        boolean hasAny = request.getName() != null || request.getPhone() != null
+                || request.getStudentNo() != null || request.getEmail() != null
+                || request.getStatus() != null || request.getRole() != null;
+        if (!hasAny) {
+            throw new MemberException("수정할 항목이 없습니다.", HttpStatus.BAD_REQUEST);
+        }
+
+        // 이름: 문자만
+        if (request.getName() != null) {
+            String name = request.getName().trim();
+            if (name.isEmpty() || !NAME_PATTERN.matcher(name).matches()) {
+                throw new MemberException("이름은 문자만 입력할 수 있습니다.", HttpStatus.BAD_REQUEST);
+            }
+            request.setName(name);
+        }
+
+        // 전화번호: 8자리(4-4) 숫자만 → "0000-0000" 형식으로 저장
+        if (request.getPhone() != null) {
+            String digits = request.getPhone().replaceAll("[^0-9]", "");
+            if (!PHONE_DIGITS_PATTERN.matcher(digits).matches()) {
+                throw new MemberException("전화번호는 숫자 8자리여야 합니다.", HttpStatus.BAD_REQUEST);
+            }
+            String formatted = digits.substring(0, 4) + "-" + digits.substring(4);
+            if (memberMapper.existsPhoneExcludingUser(formatted, userId)) {
+                throw new MemberException("이미 사용 중인 전화번호입니다.", HttpStatus.CONFLICT);
+            }
+            request.setPhone(formatted);
+        }
+
+        // 학번: 10자리 숫자만
+        if (request.getStudentNo() != null) {
+            String studentNo = request.getStudentNo().trim();
+            if (!STUDENT_NO_PATTERN.matcher(studentNo).matches()) {
+                throw new MemberException("학번은 숫자 10자리여야 합니다.", HttpStatus.BAD_REQUEST);
+            }
+            if (memberMapper.existsStudentNoExcludingUser(studentNo, userId)) {
+                throw new MemberException("이미 사용 중인 학번입니다.", HttpStatus.CONFLICT);
+            }
+            request.setStudentNo(studentNo);
+        }
+
+        // 이메일: 형식 검증 + 중복 확인
+        if (request.getEmail() != null) {
+            String email = request.getEmail().trim();
+            if (!EMAIL_PATTERN.matcher(email).matches()) {
+                throw new MemberException("올바른 이메일 형식이 아닙니다.", HttpStatus.BAD_REQUEST);
+            }
+            if (memberMapper.existsEmailExcludingUser(email, userId)) {
+                throw new MemberException("이미 사용 중인 이메일입니다.", HttpStatus.CONFLICT);
+            }
+            request.setEmail(email);
+        }
+
+        // 재학상태: 0/1/2
+        if (request.getStatus() != null && !ALLOWED_STATUS.contains(request.getStatus())) {
+            throw new MemberException("유효하지 않은 재학상태 값입니다.", HttpStatus.BAD_REQUEST);
+        }
+
+        // 권한: 허용된 role 값
+        if (request.getRole() != null && !ALLOWED_ROLES.contains(request.getRole())) {
+            throw new MemberException("유효하지 않은 권한 값입니다.", HttpStatus.BAD_REQUEST);
+        }
+
+        memberMapper.updateMember(userId, request);
+        log.info("회원 정보 수정 완료 - userId: {}, 요청: {}", userId, request);
+        return new MemberResponse("회원 정보가 수정되었습니다.", userId);
     }
 }

--- a/src/main/java/com/back/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/back/member/service/MemberServiceImpl.java
@@ -1,8 +1,10 @@
 package com.back.member.service;
 
+import com.back.member.dto.MemberBanRequest;
 import com.back.member.dto.MemberListResponse;
 import com.back.member.dto.MemberPageResponse;
 import com.back.member.dto.MemberResponse;
+import com.back.member.dto.MemberSuspendRequest;
 import com.back.member.dto.MemberUpdateRequest;
 import com.back.member.exception.MemberException;
 import com.back.member.mapper.MemberMapper;
@@ -13,7 +15,9 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Pattern;
 
@@ -38,6 +42,14 @@ public class MemberServiceImpl implements MemberService {
     private static final Set<Integer> ALLOWED_STATUS = Set.of(0, 1, 2);
     // 권한: DB에 저장되는 실제 role 값 (관리 Lv 체계는 추후 확장)
     private static final Set<String> ALLOWED_ROLES = Set.of("ADMIN", "STUDENTS", "ALUMNI");
+
+    // ===== 정지/차단 상수 =====
+    // ban_log.warning_no는 ban_policy FK 통과용. 수동 차단은 기존 정책값 재사용
+    // (임시=1/BAN_W1, 영구=3/BAN_W3). 실제 유형·기간은 ban_type·ends_at가 담당.
+    private static final int WARNING_NO_TEMPORARY = 1;
+    private static final int WARNING_NO_PERMANENT = 3;
+    private static final String BAN_TYPE_TEMPORARY = "temporary";
+    private static final String BAN_TYPE_PERMANENT = "permanent";
 
     // 관리자 권한 확인 (경로는 SecurityConfig에서 이미 ADMIN 제한, 방어적으로 한 번 더 확인)
     private void checkAdminRole() {
@@ -151,5 +163,68 @@ public class MemberServiceImpl implements MemberService {
         memberMapper.updateMember(userId, request);
         log.info("회원 정보 수정 완료 - userId: {}, 요청: {}", userId, request);
         return new MemberResponse("회원 정보가 수정되었습니다.", userId);
+    }
+
+    @Override
+    @Transactional
+    public MemberResponse suspendMember(Long userId, MemberSuspendRequest request) {
+        checkAdminRole();
+
+        if (!memberMapper.existsActiveMember(userId)) {
+            throw new MemberException("해당 회원을 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+        }
+        if (request.getEndDate() == null) {
+            throw new MemberException("정지 종료일은 필수입니다.", HttpStatus.BAD_REQUEST);
+        }
+
+        // 시작 = 지금, 종료 = 종료일의 하루 끝(23:59:59). 종료는 항상 시작보다 미래여야 함
+        LocalDateTime startsAt = LocalDateTime.now();
+        LocalDateTime endsAt = request.getEndDate().atTime(23, 59, 59);
+        if (!endsAt.isAfter(startsAt)) {
+            throw new MemberException("정지 종료일은 현재 시점보다 미래여야 합니다.", HttpStatus.BAD_REQUEST);
+        }
+
+        memberMapper.insertBanLog(userId, WARNING_NO_TEMPORARY, BAN_TYPE_TEMPORARY, startsAt, endsAt);
+        memberMapper.updateUserBanStatus(userId, BAN_TYPE_TEMPORARY, endsAt);
+
+        log.info("회원 정지 완료 - userId: {}, 종료일: {}", userId, request.getEndDate());
+        return new MemberResponse("회원이 정지되었습니다. (종료일: " + request.getEndDate() + ")", userId);
+    }
+
+    @Override
+    @Transactional
+    public MemberResponse banMembers(MemberBanRequest request) {
+        checkAdminRole();
+
+        if (request.getUserIds() == null || request.getUserIds().isEmpty()) {
+            throw new MemberException("차단할 회원을 선택해야 합니다.", HttpStatus.BAD_REQUEST);
+        }
+
+        // null 제거 + 중복 제거
+        List<Long> targetIds = request.getUserIds().stream()
+                .filter(Objects::nonNull)
+                .distinct()
+                .toList();
+        if (targetIds.isEmpty()) {
+            throw new MemberException("차단할 회원을 선택해야 합니다.", HttpStatus.BAD_REQUEST);
+        }
+
+        // 존재하지 않는 회원이 섞여 있으면 전체 실패 (트랜잭션 all-or-nothing)
+        List<Long> missing = targetIds.stream()
+                .filter(id -> !memberMapper.existsActiveMember(id))
+                .toList();
+        if (!missing.isEmpty()) {
+            throw new MemberException("존재하지 않는 회원이 포함되어 있습니다: " + missing, HttpStatus.NOT_FOUND);
+        }
+
+        LocalDateTime startsAt = LocalDateTime.now();
+        for (Long id : targetIds) {
+            // 영구차단: ends_at/banned_until = null
+            memberMapper.insertBanLog(id, WARNING_NO_PERMANENT, BAN_TYPE_PERMANENT, startsAt, null);
+            memberMapper.updateUserBanStatus(id, BAN_TYPE_PERMANENT, null);
+        }
+
+        log.info("회원 영구차단 완료 - {}명, ids: {}", targetIds.size(), targetIds);
+        return new MemberResponse(targetIds.size() + "명을 영구차단했습니다.", null);
     }
 }

--- a/src/main/java/com/back/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/back/member/service/MemberServiceImpl.java
@@ -1,0 +1,58 @@
+package com.back.member.service;
+
+import com.back.member.dto.MemberListResponse;
+import com.back.member.dto.MemberPageResponse;
+import com.back.member.exception.MemberException;
+import com.back.member.mapper.MemberMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MemberServiceImpl implements MemberService {
+
+    private final MemberMapper memberMapper;
+
+    // 관리자 권한 확인 (경로는 SecurityConfig에서 이미 ADMIN 제한, 방어적으로 한 번 더 확인)
+    private void checkAdminRole() {
+        boolean isAdmin = SecurityContextHolder.getContext().getAuthentication().getAuthorities().stream()
+                .anyMatch(a -> a.getAuthority().equals("ROLE_ADMIN"));
+        if (!isAdmin) {
+            throw new MemberException("관리자 권한이 필요합니다.", HttpStatus.FORBIDDEN);
+        }
+    }
+
+    @Override
+    public MemberPageResponse getMembers(int page, int size, String keyword, String sort) {
+        checkAdminRole();
+
+        if (page < 1) {
+            throw new MemberException("페이지 번호는 1 이상이어야 합니다.", HttpStatus.BAD_REQUEST);
+        }
+        if (size < 1) {
+            throw new MemberException("페이지 크기는 1 이상이어야 합니다.", HttpStatus.BAD_REQUEST);
+        }
+
+        long totalCount = memberMapper.countMembers(keyword);
+        int totalPages = (int) Math.ceil((double) totalCount / size);
+
+        // 검색 결과가 없으면(회원 0명) 빈 목록을 그대로 반환 - 관리자 화면이므로 에러로 막지 않음
+        List<MemberListResponse> members = totalCount == 0
+                ? List.of()
+                : memberMapper.findMembers(keyword, sort, (page - 1) * size, size);
+
+        MemberPageResponse response = new MemberPageResponse();
+        response.setTotalPages(totalPages);
+        response.setTotalCount(totalCount);
+        response.setMembers(members);
+        return response;
+    }
+}

--- a/src/main/java/com/back/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/back/member/service/MemberServiceImpl.java
@@ -32,8 +32,6 @@ public class MemberServiceImpl implements MemberService {
     // ===== 회원 정보 수정 검증 규칙 =====
     // 이름: 한글/영문 문자만 (숫자·특수문자 불가), 공백 허용
     private static final Pattern NAME_PATTERN = Pattern.compile("^[가-힣a-zA-Z\\s]+$");
-    // 전화번호: 숫자 8자리 (하이픈 제거 후 검증)
-    private static final Pattern PHONE_DIGITS_PATTERN = Pattern.compile("^\\d{8}$");
     // 학번: 숫자 10자리
     private static final Pattern STUDENT_NO_PATTERN = Pattern.compile("^\\d{10}$");
     // 이메일 형식
@@ -113,17 +111,17 @@ public class MemberServiceImpl implements MemberService {
             request.setName(name);
         }
 
-        // 전화번호: 8자리(4-4) 숫자만 → "0000-0000" 형식으로 저장
+        // 전화번호: 회원가입(signup)과 동일하게 형식 제한 없이 원본 그대로 저장.
+        // signup은 phone에 검증/정규화가 전혀 없어 010-1234-5678 같은 실제 번호가 이미 저장돼 있으므로,
+        // 여기서 자릿수/형식을 강제하면 그런 회원의 phone을 admin이 재저장할 수 없게 됨.
+        // 단, 중복은 저장 형식 차이(하이픈 유무)와 무관하게 숫자 기준으로 미리 잡아 DB unique 충돌(500) 방지.
         if (request.getPhone() != null) {
-            String digits = request.getPhone().replaceAll("[^0-9]", "");
-            if (!PHONE_DIGITS_PATTERN.matcher(digits).matches()) {
-                throw new MemberException("전화번호는 숫자 8자리여야 합니다.", HttpStatus.BAD_REQUEST);
-            }
-            String formatted = digits.substring(0, 4) + "-" + digits.substring(4);
-            if (memberMapper.existsPhoneExcludingUser(formatted, userId)) {
+            String phone = request.getPhone().trim();
+            String digits = phone.replaceAll("[^0-9]", "");
+            if (!digits.isEmpty() && memberMapper.existsPhoneDigitsExcludingUser(digits, userId)) {
                 throw new MemberException("이미 사용 중인 전화번호입니다.", HttpStatus.CONFLICT);
             }
-            request.setPhone(formatted);
+            request.setPhone(phone);
         }
 
         // 학번: 10자리 숫자만
@@ -173,6 +171,10 @@ public class MemberServiceImpl implements MemberService {
         if (!memberMapper.existsActiveMember(userId)) {
             throw new MemberException("해당 회원을 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
         }
+        // 이미 영구차단된 회원을 임시정지로 덮어쓰면 만료 시 영구차단이 사라지므로 차단
+        if (BAN_TYPE_PERMANENT.equals(memberMapper.findBanStatus(userId))) {
+            throw new MemberException("이미 영구차단된 회원입니다. 정지로 변경할 수 없습니다.", HttpStatus.CONFLICT);
+        }
         if (request.getEndDate() == null) {
             throw new MemberException("정지 종료일은 필수입니다.", HttpStatus.BAD_REQUEST);
         }
@@ -209,20 +211,17 @@ public class MemberServiceImpl implements MemberService {
             throw new MemberException("차단할 회원을 선택해야 합니다.", HttpStatus.BAD_REQUEST);
         }
 
-        // 존재하지 않는 회원이 섞여 있으면 전체 실패 (트랜잭션 all-or-nothing)
-        List<Long> missing = targetIds.stream()
-                .filter(id -> !memberMapper.existsActiveMember(id))
-                .toList();
-        if (!missing.isEmpty()) {
+        // 존재 확인 1회 (WHERE user_id IN ...). 없는 회원이 섞이면 전체 실패
+        List<Long> found = memberMapper.findActiveMemberIds(targetIds);
+        if (found.size() != targetIds.size()) {
+            List<Long> missing = targetIds.stream().filter(id -> !found.contains(id)).toList();
             throw new MemberException("존재하지 않는 회원이 포함되어 있습니다: " + missing, HttpStatus.NOT_FOUND);
         }
 
+        // 영구차단: ends_at/banned_until = null. INSERT 1회(batch) + UPDATE 1회로 처리
         LocalDateTime startsAt = LocalDateTime.now();
-        for (Long id : targetIds) {
-            // 영구차단: ends_at/banned_until = null
-            memberMapper.insertBanLog(id, WARNING_NO_PERMANENT, BAN_TYPE_PERMANENT, startsAt, null);
-            memberMapper.updateUserBanStatus(id, BAN_TYPE_PERMANENT, null);
-        }
+        memberMapper.insertBanLogBatch(targetIds, WARNING_NO_PERMANENT, BAN_TYPE_PERMANENT, startsAt, null);
+        memberMapper.updateUserBanStatusByIds(targetIds, BAN_TYPE_PERMANENT, null);
 
         log.info("회원 영구차단 완료 - {}명, ids: {}", targetIds.size(), targetIds);
         return new MemberResponse(targetIds.size() + "명을 영구차단했습니다.", null);

--- a/src/main/resources/mapper/member/MemberMapper.xml
+++ b/src/main/resources/mapper/member/MemberMapper.xml
@@ -23,7 +23,13 @@
             u.email        AS email,
             u.status       AS status,
             u.role         AS role,
-            u.ban_status   AS banStatus,
+            -- banStatus는 캐시 컬럼(u.ban_status) 대신 조인된 현재 유효 차단에서 파생
+            -- → 임시정지 만료 시 자동으로 'none'이 되어 banStartAt/banEndAt과 항상 일치
+            CASE
+                WHEN b.starts_at IS NULL THEN 'none'
+                WHEN b.ends_at IS NULL   THEN 'permanent'
+                ELSE 'temporary'
+            END AS banStatus,
             (SELECT COUNT(*) FROM posts p    WHERE p.user_id = u.user_id) AS postCount,
             (SELECT COUNT(*) FROM comments c WHERE c.user_id = u.user_id) AS commentCount,
             b.starts_at    AS banStartAt,
@@ -74,10 +80,12 @@
         )
     </select>
 
-    <select id="existsPhoneExcludingUser" resultType="boolean">
+    <!-- 저장 형식(하이픈 유무)이 달라도 중복을 잡도록, 저장된 phone의 하이픈/공백을 제거한 숫자끼리 비교 -->
+    <select id="existsPhoneDigitsExcludingUser" resultType="boolean">
         SELECT EXISTS (
             SELECT 1 FROM users
-            WHERE phone = #{phone} AND user_id != #{userId}
+            WHERE REPLACE(REPLACE(phone, '-', ''), ' ', '') = #{phoneDigits}
+              AND user_id != #{userId}
         )
     </select>
 
@@ -104,19 +112,53 @@
 
     <!-- ===== 회원 정지 / 영구차단 ===== -->
 
-    <!-- 차단 이력 기록 (ends_at = null 이면 영구) -->
+    <!-- 현재 차단 상태 캐시 조회 (정지 전 영구차단 여부 확인용) -->
+    <select id="findBanStatus" resultType="string">
+        SELECT ban_status FROM users WHERE user_id = #{userId}
+    </select>
+
+    <!-- 차단 이력 기록 (단일 - 정지용, ends_at = null 이면 영구) -->
     <insert id="insertBanLog">
         INSERT INTO ban_log (user_id, warning_no, ban_type, starts_at, ends_at, created_at)
         VALUES (#{userId}, #{warningNo}, #{banType}, #{startsAt}, #{endsAt}, NOW())
     </insert>
 
-    <!-- users 차단 상태 캐시 갱신 (banned_until = null 이면 영구) -->
+    <!-- users 차단 상태 캐시 갱신 (단일 - 정지용, banned_until = null 이면 영구) -->
     <update id="updateUserBanStatus">
         UPDATE users
         SET ban_status   = #{banStatus},
             banned_until = #{bannedUntil},
             updated_at   = NOW()
         WHERE user_id = #{userId} AND is_deleted = 0
+    </update>
+
+    <!-- 주어진 id 중 실제 존재하는(미탈퇴) 회원 id만 반환 - 영구차단 일괄 검증용 -->
+    <select id="findActiveMemberIds" resultType="long">
+        SELECT user_id
+        FROM users
+        WHERE is_deleted = 0
+          AND user_id IN
+          <foreach collection="ids" item="id" open="(" close=")" separator=",">#{id}</foreach>
+    </select>
+
+    <!-- 차단 이력 일괄 기록 (영구차단용 - 공통 값 + 회원별 1행) -->
+    <insert id="insertBanLogBatch">
+        INSERT INTO ban_log (user_id, warning_no, ban_type, starts_at, ends_at, created_at)
+        VALUES
+        <foreach collection="userIds" item="id" separator=",">
+            (#{id}, #{warningNo}, #{banType}, #{startsAt}, #{endsAt}, NOW())
+        </foreach>
+    </insert>
+
+    <!-- users 차단 상태 캐시 일괄 갱신 (영구차단용) -->
+    <update id="updateUserBanStatusByIds">
+        UPDATE users
+        SET ban_status   = #{banStatus},
+            banned_until = #{bannedUntil},
+            updated_at   = NOW()
+        WHERE is_deleted = 0
+          AND user_id IN
+          <foreach collection="userIds" item="id" open="(" close=")" separator=",">#{id}</foreach>
     </update>
 
 </mapper>

--- a/src/main/resources/mapper/member/MemberMapper.xml
+++ b/src/main/resources/mapper/member/MemberMapper.xml
@@ -58,4 +58,48 @@
         </trim>
     </select>
 
+    <!-- ===== 회원 정보 수정 ===== -->
+
+    <select id="existsActiveMember" resultType="boolean">
+        SELECT EXISTS (
+            SELECT 1 FROM users
+            WHERE user_id = #{userId} AND is_deleted = 0
+        )
+    </select>
+
+    <select id="existsEmailExcludingUser" resultType="boolean">
+        SELECT EXISTS (
+            SELECT 1 FROM users
+            WHERE email = #{email} AND user_id != #{userId}
+        )
+    </select>
+
+    <select id="existsPhoneExcludingUser" resultType="boolean">
+        SELECT EXISTS (
+            SELECT 1 FROM users
+            WHERE phone = #{phone} AND user_id != #{userId}
+        )
+    </select>
+
+    <select id="existsStudentNoExcludingUser" resultType="boolean">
+        SELECT EXISTS (
+            SELECT 1 FROM users
+            WHERE student_no = #{studentNo} AND user_id != #{userId}
+        )
+    </select>
+
+    <update id="updateMember">
+        UPDATE users
+        <set>
+            <if test="req.name != null">name = #{req.name},</if>
+            <if test="req.phone != null">phone = #{req.phone},</if>
+            <if test="req.studentNo != null">student_no = #{req.studentNo},</if>
+            <if test="req.email != null">email = #{req.email},</if>
+            <if test="req.status != null">status = #{req.status},</if>
+            <if test="req.role != null">role = #{req.role},</if>
+            updated_at = NOW()
+        </set>
+        WHERE user_id = #{userId} AND is_deleted = 0
+    </update>
+
 </mapper>

--- a/src/main/resources/mapper/member/MemberMapper.xml
+++ b/src/main/resources/mapper/member/MemberMapper.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.back.member.mapper.MemberMapper">
+
+    <!-- 검색 조건 (ID / 이름 / 학번 / 이메일) - 목록/카운트 공통 -->
+    <sql id="searchCondition">
+        AND u.is_deleted = 0
+        <if test="keyword != null and keyword != ''">
+            AND (u.login_id   LIKE CONCAT('%', #{keyword}, '%')
+              OR u.name       LIKE CONCAT('%', #{keyword}, '%')
+              OR u.student_no LIKE CONCAT('%', #{keyword}, '%')
+              OR u.email      LIKE CONCAT('%', #{keyword}, '%'))
+        </if>
+    </sql>
+
+    <select id="findMembers" resultType="com.back.member.dto.MemberListResponse">
+        SELECT
+            u.user_id      AS userId,
+            u.login_id     AS loginId,
+            u.name         AS name,
+            u.phone        AS phone,
+            u.student_no   AS studentNo,
+            u.email        AS email,
+            u.status       AS status,
+            u.role         AS role,
+            u.ban_status   AS banStatus,
+            (SELECT COUNT(*) FROM posts p    WHERE p.user_id = u.user_id) AS postCount,
+            (SELECT COUNT(*) FROM comments c WHERE c.user_id = u.user_id) AS commentCount,
+            b.starts_at    AS banStartAt,
+            b.ends_at      AS banEndAt
+        FROM users u
+        LEFT JOIN (
+            -- 회원별 현재 유효한(해제 안 됐고 만료 전) 차단 1건
+            SELECT bl.user_id,
+                   bl.starts_at,
+                   bl.ends_at,
+                   ROW_NUMBER() OVER (PARTITION BY bl.user_id ORDER BY bl.starts_at DESC) AS rn
+            FROM ban_log bl
+            WHERE bl.lifted_at IS NULL
+              AND (bl.ends_at IS NULL OR bl.ends_at > NOW())
+        ) b ON b.user_id = u.user_id AND b.rn = 1
+        <trim prefix="WHERE" prefixOverrides="AND">
+            <include refid="searchCondition"/>
+        </trim>
+        ORDER BY
+        <choose>
+            <when test="sort == 'oldest'">u.created_at ASC</when>
+            <otherwise>u.created_at DESC</otherwise>
+        </choose>
+        LIMIT #{size} OFFSET #{offset}
+    </select>
+
+    <select id="countMembers" resultType="long">
+        SELECT COUNT(*)
+        FROM users u
+        <trim prefix="WHERE" prefixOverrides="AND">
+            <include refid="searchCondition"/>
+        </trim>
+    </select>
+
+</mapper>

--- a/src/main/resources/mapper/member/MemberMapper.xml
+++ b/src/main/resources/mapper/member/MemberMapper.xml
@@ -102,4 +102,21 @@
         WHERE user_id = #{userId} AND is_deleted = 0
     </update>
 
+    <!-- ===== 회원 정지 / 영구차단 ===== -->
+
+    <!-- 차단 이력 기록 (ends_at = null 이면 영구) -->
+    <insert id="insertBanLog">
+        INSERT INTO ban_log (user_id, warning_no, ban_type, starts_at, ends_at, created_at)
+        VALUES (#{userId}, #{warningNo}, #{banType}, #{startsAt}, #{endsAt}, NOW())
+    </insert>
+
+    <!-- users 차단 상태 캐시 갱신 (banned_until = null 이면 영구) -->
+    <update id="updateUserBanStatus">
+        UPDATE users
+        SET ban_status   = #{banStatus},
+            banned_until = #{bannedUntil},
+            updated_at   = NOW()
+        WHERE user_id = #{userId} AND is_deleted = 0
+    </update>
+
 </mapper>


### PR DESCRIPTION
## 작업 내용
관리자 '회원 관리 > 회원 목록' 백엔드 기능 4종 구현 (조회 + 수정 + 정지 + 영구차단)

### 1. 전체 회원 조회 — `GET /api/admin/members` (관리자 전용)
- 검색: ID(login_id)/이름/학번/이메일 부분일치
- 정렬: 최신순(기본), 오래된순(`sort=oldest`)
- 페이지네이션: `page`/`size`, 응답에 `totalPages`·`totalCount` 포함
- 회원별 게시글 수·댓글 수 집계
- 정지 기간: ban_log에서 현재 유효한 차단 1건 조인(ROW_NUMBER)해 시작/종료일 표시
- 탈퇴 회원(is_deleted=1) 제외

### 2. 회원 정보 수정 — `PUT /api/admin/members/{userId}` (관리자 전용)
- 부분 수정: 전달된 필드만 검증·수정
- 검증: 이름=문자만, 전화=8자리(4-4)→`0000-0000` 저장, 학번=10자리 숫자, 이메일 형식
- 이메일/전화/학번 본인 제외 중복 검사
- 재학상태(status: 0/1/2), 권한(role: ADMIN/STUDENTS/ALUMNI) 값 검증
- 없는/탈퇴 회원 수정 시 404

### 3. 회원 정지(temporary) — `POST /api/admin/members/{userId}/suspend` (관리자 전용)
- 단일 회원, 입력한 종료일까지 정지 / 종료일 미래 검증
- ban_log 기록 + users(ban_status='temporary', banned_until) 갱신

### 4. 회원 영구차단(permanent) — `POST /api/admin/members/ban` (관리자 전용)
- 단일/다중 회원(userIds 배열)
- ban_log 기록(ends_at=NULL) + users(ban_status='permanent', banned_until=NULL) 갱신
- 존재하지 않는 id 포함 시 전체 실패(트랜잭션 all-or-nothing)

## 요청/응답 예시
- 조회 응답:
      { "totalPages": 3, "totalCount": 23, "members": [ { "loginId": "CH400", "name": "김철수", "postCount": 3, "commentCount": 6, "banStartAt": null, "banEndAt": null } ] }
- 정보 수정: `PUT /api/admin/members/5` → `{ "phone": "0000-0000", "role": "ADMIN" }`
- 정지: `POST /api/admin/members/5/suspend` → `{ "endDate": "2026-05-05" }`
- 영구차단: `POST /api/admin/members/ban` → `{ "userIds": [5, 6, 7] }`

## 참고 / 결정사항
- 화면의 "ID" 컬럼은 닉네임 컬럼이 없어 `users.login_id`로 매핑 (추후 조정 가능)
- 권한(role)/재학상태(status)는 DB 실제 값 기준으로 검증. 화면의 "관리 Lv.1~3"·"재학생/졸업생" 라벨은 프론트에서 매핑
- 날짜 API는 ISO 형식(`YYYY-MM-DD`)으로 수신 (화면 yy.mm.dd는 프론트에서 변환)
- ban_log.warning_no는 ban_policy FK 통과용으로 기존 정책값 재사용(임시=1, 영구=3). 실제 유형/기간은 ban_type·ends_at가 담당
- 정지 해제(unban)는 와이어프레임에 없어 미구현

## 확인
- 로컬 컴파일(BUILD SUCCESSFUL) 및 서버 기동 확인, Swagger에 엔드포인트 4종 등록 확인
- 관리자 인증 없이 호출 시 403(정상)