### PR TITLE
[BE] 로그인 권한 정리 — 역할별 접근에서 ADMIN 제거

### DIFF
--- a/src/main/java/com/back/global/config/SecurityConfig.java
+++ b/src/main/java/com/back/global/config/SecurityConfig.java
@@ -45,9 +45,14 @@ public class SecurityConfig {
                 ).permitAll()
                 
                 // 역할별 접근
-                .requestMatchers("/api/admin/**").hasRole("ADMIN")
-                .requestMatchers("/api/stu/**").hasAnyRole("STUDENTS", "ADMIN", "ALUMNI") // ALUMNI는 임시!
-                .requestMatchers("/api/alu/**").hasAnyRole("ALUMNI", "ADMIN")
+                // ⚠️ [PM 지시] role 2축 분리 준비 — 역할별 접근에서 ADMIN 전면 제거.
+                //   /api/admin 은 URL 레벨 ADMIN 가드 제거(= 로그인 사용자면 통과).
+                //   현재 quotes/schedules/notices 는 서비스 내부에서 ROLE_ADMIN 재검사하므로 실질 노출 없음.
+                //   ※ 앞으로 추가되는 /api/admin 엔드포인트는 반드시 서비스 내부에서 관리자 검사를 넣을 것
+                //     (관리자 구분 컬럼 도입 후 URL 가드 재설계 예정).
+                .requestMatchers("/api/admin/**").authenticated()
+                .requestMatchers("/api/stu/**").hasAnyRole("STUDENTS", "ALUMNI") // ADMIN 제거(역할 2축 분리 준비). ALUMNI는 임시
+                .requestMatchers("/api/alu/**").hasAnyRole("ALUMNI") // ADMIN 제거
                 
                 // 그 외는 로그인 필요
                 .anyRequest().authenticated()

--- a/src/main/java/com/back/global/security/JwtUtil.java
+++ b/src/main/java/com/back/global/security/JwtUtil.java
@@ -45,7 +45,7 @@ public class JwtUtil {
                 // 토큰에 추가하고 싶은 정보
                 .setSubject(user.getLoginId())
                 .claim("id", user.getUserId())
-                .claim("role", user.getRole())
+                // role claim 제거: 리프레시(갱신권)는 role을 읽지 않음(재발급 시 DB에서 재조회) — 죽은 도장 정리
                 .claim("name", user.getName())
                 // 토큰 기본 정보
                 .setIssuedAt(new Date())


### PR DESCRIPTION
## 변경 요약 (PM 지시: 역할별 접근에서 ADMIN 전면 제거 / 역할 2축 분리 준비)
- `SecurityConfig`: `/api/stu`·`/api/alu` 접근 목록에서 **ADMIN 제거**, `/api/admin` URL 가드도 제거(`authenticated`)
- `JwtUtil.generateRefreshToken`: 사용되지 않는 `role` claim 제거 (**동작 변화 없음** — 재발급 시 DB 재조회라 갱신권의 role은 아무도 안 읽음)

## 사이드 이펙트
- ⚠️ 관리자(role=ADMIN)가 `/api/stu/free`, `/api/stu/info` 게시판 **모더레이션(남의 글 수정/삭제) 접근 불가**
- 🟢 관리자 기능 `quotes`/`schedules`/`notices`(`/api/admin/**`)는 **서비스 내부에서 ROLE_ADMIN 재검사**하므로 정상 동작 + 실질 노출 없음
- 🟢 일반 학생/졸업생 사용, **로그인 자체 영향 없음**

## ⚠️ 리뷰 시 확인 요청
- `/api/admin`의 URL 레벨 관리자 가드를 제거했습니다. 현재 엔드포인트(quotes/schedules/notices)는 서비스 내부 검사로 방어되지만,
  **앞으로 추가되는 `/api/admin` 엔드포인트는 반드시 서비스 내부에서 관리자 검사를 넣어야 합니다.**
  (관리자 구분 컬럼 도입 후 URL 가드 재설계 예정)

## 아직 안 한 것 (후속)
- `role → member_type` 전면 전환: `users`에 `member_type` 컬럼이 아직 없어 **보류**
- 접속증(access token) `role` claim / 필터의 role 판별 / 5곳 `ROLE_ADMIN` 체크: **관리자 판별에 쓰여 유지**

## 검증
- `./gradlew compileJava` 통과
- 실제 권한 동작(관리자 stu 접근 제한 등)은 로컬에서 qa_pilsa 직접 연결 불가 → **QA 배포 환경 + 관리자 토큰**으로 확인 필요
