### PR TITLE
[BE] 리프레시 토큰 회전(sliding) — 활동 중 로그인 유지

### DIFF
--- a/src/main/java/com/back/auth/controller/AuthController.java
+++ b/src/main/java/com/back/auth/controller/AuthController.java
@@ -119,14 +119,14 @@ public class AuthController {
         return ResponseEntity.ok(authService.extend(refreshToken, response));
     }
 
-    // 엑세스 토큰 발급/재발급
+    // 엑세스 토큰 발급/재발급 (+ 리프레시 토큰 회전)
     @PostMapping("/token/access/refresh")
-    public ResponseEntity<AuthResponse> refresh(HttpServletRequest request) {
+    public ResponseEntity<AuthResponse> refresh(HttpServletRequest request, HttpServletResponse response) {
         String refreshToken = extractRefreshToken(request);
         if (refreshToken == null) {
             return ResponseEntity.status(401).build();
         }
-        return ResponseEntity.ok(authService.refresh(refreshToken));
+        return ResponseEntity.ok(authService.refresh(refreshToken, response));
     }
 
     // 아이디 찾기 전용 - 이메일+인증번호 검증

--- a/src/main/java/com/back/auth/service/AuthService.java
+++ b/src/main/java/com/back/auth/service/AuthService.java
@@ -33,6 +33,6 @@ public interface AuthService {
     boolean checkRefreshToken(HttpServletRequest request);
     // 리프레시토큰 연장(재발급) -> 로그인 시 수동 연장
     AuthResponse extend(String refreshToken, HttpServletResponse response);
-    // 엑세스 토큰 발급/재발급
-    AuthResponse refresh(String refreshToken);
+    // 엑세스 토큰 발급/재발급 (+ 리프레시 토큰 회전: 활동 중이면 리프레시도 계속 갱신)
+    AuthResponse refresh(String refreshToken, HttpServletResponse response);
 }

--- a/src/main/java/com/back/auth/service/AuthServicempl.java
+++ b/src/main/java/com/back/auth/service/AuthServicempl.java
@@ -317,8 +317,8 @@ public class AuthServicempl implements AuthService {
         }
     }
 
-    // 엑세스 토큰 발급/재발급
-    public AuthResponse refresh(String refreshToken) {
+    // 엑세스 토큰 발급/재발급 (+ 리프레시 토큰 회전)
+    public AuthResponse refresh(String refreshToken, HttpServletResponse response) {
         try {
             var claims = jwtUtil.validateRefreshToken(refreshToken);
             String loginId = claims.getSubject();
@@ -332,9 +332,13 @@ public class AuthServicempl implements AuthService {
                 throw new AuthException("탈퇴했거나 승인되지 않은 계정입니다.", HttpStatus.UNAUTHORIZED);
             }
 
-            // 기존 refreshToken 그대로 쓰므로 exp도 동일
-            long refreshExp = claims.getExpiration().getTime();
+            // 액세스 재발급 + 리프레시 토큰 회전(sliding):
+            // 활동으로 access를 재발급받을 때마다 refresh도 새로 발급해 쿠키를 교체 → 리프레시 토큰이 계속 갱신됨
             String newAccessToken = jwtUtil.generateAccessToken(user);
+            String newRefreshToken = jwtUtil.generateRefreshToken(user);
+            addRefreshTokenCookie(response, newRefreshToken);
+
+            long refreshExp = jwtUtil.validateRefreshToken(newRefreshToken).getExpiration().getTime();
 
             return new AuthResponse(newAccessToken, user.getUserId(), user.getRole(), refreshExp);
 


### PR DESCRIPTION
## 변경 요약
- `/token/access/refresh`(액세스 토큰 자동 재발급) 시 **리프레시 토큰도 함께 회전**(재발급 + 쿠키 교체) — sliding session
- 기존: access만 재발급 → refresh 12h 시계가 리셋 안 돼 **활동 중에도 12시간 후 강제 로그아웃**
- 변경: 활동으로 재발급받을 때마다 refresh 시계도 리셋 → **활발히 사용하는 동안 로그아웃 안 됨**
- `AuthService.refresh` 시그니처에 `HttpServletResponse` 추가(쿠키 교체용)

## 변경 파일
- `AuthController` / `AuthService` / `AuthServicempl` — `/token/access/refresh` 경로만

## 참고
- `extend`(수동 연장)와 로직이 거의 동일해짐 — 프론트가 `extend`도 사용 중이라 이번엔 통합하지 않고 유지
- 쿠키 `setMaxAge`(세션쿠키→영속) 건은 별도 이슈(브라우저 종료 시 로그아웃)로, 이번 스코프 제외

## 검증
- `./gradlew compileJava` 통과
- 실제 재발급 동작은 로컬에서 qa_pilsa 직접 연결 불가 → **QA 배포 환경 + 로그인**으로 확인 필요
