### PR TITLE
[BE] 이메일 찾기 기능 추가 (학번+이름 → 마스킹 이메일)

### DIFF
--- a/src/main/java/com/back/auth/controller/AuthController.java
+++ b/src/main/java/com/back/auth/controller/AuthController.java
@@ -156,6 +156,21 @@ public class AuthController {
         }
     }
 
+    // 이메일 찾기 - 학번+이름 일치 시 마스킹된 이메일 반환
+    // (아이디/이메일/비번 다 잊어서 아이디 찾기용 이메일조차 모를 때 사용)
+    @PostMapping("/email/find")
+    public ResponseEntity<?> findEmail(@RequestBody FindEmailRequest request) {
+        try {
+            String maskedEmail = authService.findMaskedEmail(request.getStudentNo(), request.getName());
+            return ResponseEntity.ok(Map.of(
+                    "message", "이메일 조회 성공",
+                    "email", maskedEmail
+            ));
+        } catch (AuthException e) {
+            return ResponseEntity.status(e.getStatus()).body(e.getMessage());
+        }
+    }
+
     // 비밀번호 초기화 전 단계 - 아이디 이메일 유효성 확인
     @GetMapping("/verification")
     public ResponseEntity<?> verification(

--- a/src/main/java/com/back/auth/dto/FindEmailRequest.java
+++ b/src/main/java/com/back/auth/dto/FindEmailRequest.java
@@ -1,0 +1,12 @@
+package com.back.auth.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+// 이메일 찾기 요청 - 학번 + 이름
+@Getter
+@Setter
+public class FindEmailRequest {
+    private String studentNo;
+    private String name;
+}

--- a/src/main/java/com/back/auth/mapper/AuthMapper.java
+++ b/src/main/java/com/back/auth/mapper/AuthMapper.java
@@ -25,6 +25,9 @@ public interface AuthMapper {
     boolean existsByLoginIdAndEmail(@Param("loginId") String loginId, @Param("email") String email);
     // 비밀번호 초기화
     void updatePassword(@Param("loginId") String loginId, @Param("password") String encodedNewPassword);
+
+    // 이메일 찾기 - 학번+이름이 모두 일치하는 사용자의 이메일 조회
+    String findEmailByStudentNoAndName(@Param("studentNo") String studentNo, @Param("name") String name);
 }
 
 //@Mapper

--- a/src/main/java/com/back/auth/service/AuthService.java
+++ b/src/main/java/com/back/auth/service/AuthService.java
@@ -29,6 +29,9 @@ public interface AuthService {
     // 비밀번호 초기화
     void resetPassword(PasswordResetRequest request);
 
+    // 이메일 찾기 - 학번/이름 일치 시 마스킹된 이메일 반환
+    String findMaskedEmail(String studentNo, String name);
+
     // 리프레시 토큰을 가지고 있는 쿠키의 존재 여부 확인
     boolean checkRefreshToken(HttpServletRequest request);
     // 리프레시토큰 연장(재발급) -> 로그인 시 수동 연장

--- a/src/main/java/com/back/auth/service/AuthServicempl.java
+++ b/src/main/java/com/back/auth/service/AuthServicempl.java
@@ -250,6 +250,35 @@ public class AuthServicempl implements AuthService {
         authMapper.updatePassword(user.getLoginId(), encodedNewPassword);
     }
 
+    // 이메일 찾기 - 학번+이름 일치 시 마스킹된 이메일 반환
+    @Override
+    public String findMaskedEmail(String studentNo, String name) {
+        if (studentNo == null || studentNo.isBlank() || name == null || name.isBlank()) {
+            throw new AuthException("학번과 이름을 모두 입력해주세요.", HttpStatus.BAD_REQUEST);
+        }
+
+        // 학번+이름이 '같은 사용자'를 가리킬 때만 조회됨 (하나라도 불일치하면 null)
+        String email = authMapper.findEmailByStudentNoAndName(studentNo.trim(), name.trim());
+        if (email == null || email.isBlank()) {
+            throw new AuthException("입력하신 학번과 이름에 일치하는 회원 정보가 없습니다.", HttpStatus.NOT_FOUND);
+        }
+
+        return maskEmail(email);
+    }
+
+    // 이메일 마스킹: 로컬파트(@앞) 앞 2글자만 노출 + "***", @도메인은 그대로
+    // 예) abcdefg@gmail.com -> ab***@gmail.com
+    private String maskEmail(String email) {
+        int at = email.indexOf('@');
+        if (at <= 0) {
+            return "***"; // 형식이 이상하면 방어적으로 전부 가림
+        }
+        String local = email.substring(0, at);
+        String domain = email.substring(at); // '@' 포함
+        String prefix = local.substring(0, Math.min(2, local.length()));
+        return prefix + "***" + domain;
+    }
+
     // 리프레시 토큰을 가지고 있는 쿠키의 존재 여부 확인
     public boolean checkRefreshToken(HttpServletRequest request) {
         if (request.getCookies() != null) {

--- a/src/main/resources/mapper/auth/AuthMapper.xml
+++ b/src/main/resources/mapper/auth/AuthMapper.xml
@@ -62,6 +62,16 @@
         UPDATE users SET password_hash = #{password}
         WHERE login_id = #{loginId}
     </update>
+
+    <!-- 이메일 찾기 - 학번+이름 모두 일치 시 이메일 반환 (하나라도 다르면 결과 없음) -->
+    <select id="findEmailByStudentNoAndName" resultType="string">
+        SELECT email
+        FROM users
+        WHERE student_no = #{studentNo}
+          AND name = #{name}
+          AND is_deleted = false
+        LIMIT 1
+    </select>
 </mapper>
 
         <!--<mapper namespace="com.back.auth.mapper.AuthMapper">-->


### PR DESCRIPTION
## 기능: 이메일 찾기 (학번 + 이름 → 마스킹된 이메일)
아이디/비밀번호는 물론, 아이디 찾기에 필요한 **이메일까지 잊은** 사용자를 위해 학번+이름으로 마스킹된 이메일을 조회.

## 엔드포인트
`POST /api/auth/email/find` (permitAll, 로그인 불필요)
- 요청: `{ "studentNo": "20211234", "name": "홍길동" }`
- 성공: `{ "message": "이메일 조회 성공", "email": "ab***@gmail.com" }`
- 실패: `400`(학번/이름 미입력) / `404`(일치 회원 없음)

## 규칙
- **학번과 이름이 같은 사용자를 가리킬 때만** 이메일 반환 — 둘 중 하나라도 불일치하거나 없으면 404(노출 안 함)
- 탈퇴 회원(`is_deleted`) 제외
- 마스킹: 로컬파트(@앞) **앞 2글자 + `***`**, `@도메인`은 그대로
  - 예) `abcdefg@gmail.com` → `ab***@gmail.com`, `a@x.com` → `a***@x.com`

## 변경 파일 (6개, 기존 auth 컨벤션 동일)
- `FindEmailRequest`(dto) / `AuthMapper`(+xml) / `AuthService`(+Impl) / `AuthController`

## 비고
- **#66(권한 개편)과 독립** — `student_no`/`name`/`email`만 사용하므로 **DDL 없이 현재 스키마에서 바로 동작**(먼저 배포 가능)
- `./gradlew compileJava` 통과 / 실제 동작은 QA 배포 후 확인
