### PR TITLE
[BE] 유저 정지/영구차단 제재 시스템 및 신고 처리 기능

### DIFF
--- a/src/main/java/com/back/PilsaBackendApplication.java
+++ b/src/main/java/com/back/PilsaBackendApplication.java
@@ -2,8 +2,10 @@ package com.back;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class PilsaBackendApplication {
   
   public static void main(String[] args) {

--- a/src/main/java/com/back/auth/dto/UserDto.java
+++ b/src/main/java/com/back/auth/dto/UserDto.java
@@ -2,6 +2,8 @@ package com.back.auth.dto;
 
 import lombok.Data;
 
+import java.time.LocalDateTime;
+
 @Data
 public class UserDto {
     private Long userId;
@@ -12,4 +14,6 @@ public class UserDto {
     private String email;
     private String role;
     private Boolean isDeleted;
+    private String banStatus;
+    private LocalDateTime bannedUntil;
 }

--- a/src/main/java/com/back/auth/service/AuthServicempl.java
+++ b/src/main/java/com/back/auth/service/AuthServicempl.java
@@ -21,6 +21,7 @@ import com.back.auth.dto.FindIdVerifyRequest;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.http.HttpStatus;
 
+import java.time.LocalDateTime;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
@@ -50,6 +51,18 @@ public class AuthServicempl implements AuthService {
         response.addCookie(cookie);
     }
 
+    // 정지/영구차단 계정 로그인 차단 (만료된 임시정지는 통과 - 스케줄러가 캐시를 정리하기 전이라도 로그인 허용)
+    private void checkNotBanned(UserDto user) {
+        if ("permanent".equals(user.getBanStatus())) {
+            throw new AuthException("영구적으로 차단된 계정입니다.", HttpStatus.FORBIDDEN);
+        }
+        if ("temporary".equals(user.getBanStatus())
+                && user.getBannedUntil() != null
+                && user.getBannedUntil().isAfter(LocalDateTime.now())) {
+            throw new AuthException("정지된 계정입니다. (해제 예정일: " + user.getBannedUntil() + ")", HttpStatus.FORBIDDEN);
+        }
+    }
+
     // 로그인(소셜로그인은 후순위)
     public AuthResponse login(LoginRequest request,
                               HttpServletRequest httpRequest,
@@ -66,6 +79,9 @@ public class AuthServicempl implements AuthService {
         if (user.getIsDeleted() == true) {
             throw new AuthException("승인되지 않은 계정입니다.", HttpStatus.UNAUTHORIZED);
         }
+
+        // 정지/영구차단 계정 로그인 차단
+        checkNotBanned(user);
 
         String accessToken = jwtUtil.generateAccessToken(user);
         String refreshToken = jwtUtil.generateRefreshToken(user);
@@ -279,6 +295,7 @@ public class AuthServicempl implements AuthService {
             if (Boolean.TRUE.equals(user.getIsDeleted())) {
                 throw new AuthException("탈퇴했거나 승인되지 않은 계정입니다.", HttpStatus.UNAUTHORIZED);
             }
+            checkNotBanned(user);
 
             // 3) 새 토큰 발급
             String newAccessToken = jwtUtil.generateAccessToken(user);
@@ -331,6 +348,7 @@ public class AuthServicempl implements AuthService {
             if (Boolean.TRUE.equals(user.getIsDeleted())) {
                 throw new AuthException("탈퇴했거나 승인되지 않은 계정입니다.", HttpStatus.UNAUTHORIZED);
             }
+            checkNotBanned(user);
 
             // 기존 refreshToken 그대로 쓰므로 exp도 동일
             long refreshExp = claims.getExpiration().getTime();

--- a/src/main/java/com/back/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/back/global/security/JwtAuthenticationFilter.java
@@ -19,6 +19,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
 import java.util.Collections;
 
 // JWT Access Token 검증 필터
@@ -47,7 +48,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         }
 
         // 프런트에서 읽을 커스텀 헤더 노출 (CORS)
-        response.addHeader("Access-Control-Expose-Headers", "WWW-Authenticate, X-Token-Expired, X-Blocked");
+        response.addHeader("Access-Control-Expose-Headers", "WWW-Authenticate, X-Token-Expired, X-Blocked, X-Ban-Type");
 
         // Authorization 헤더 추출
         String header = request.getHeader("Authorization");
@@ -75,6 +76,21 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                     log.warn("차단된 계정(is_deleted=true) 접근: {}", loginId);
                     response.setHeader("X-Blocked", "true"); // 프론트에서 탈퇴여부를 판단할 사용자 정의 헤더
                     response.sendError(HttpServletResponse.SC_GONE, "탈퇴되었거나 승인되지 않은 계정입니다.");
+                    response.flushBuffer();
+                    return;
+                }
+
+                // 정지/영구차단 계정 접근 차단 (세션 도중 제재된 경우 대비)
+                boolean isPermanentBan = "permanent".equals(user.getBanStatus());
+                boolean isTemporaryBan = "temporary".equals(user.getBanStatus())
+                        && user.getBannedUntil() != null
+                        && user.getBannedUntil().isAfter(LocalDateTime.now());
+                if (isPermanentBan || isTemporaryBan) {
+                    log.warn("제재된 계정 접근: {} (banStatus={})", loginId, user.getBanStatus());
+                    response.setHeader("X-Ban-Type", user.getBanStatus());
+                    response.sendError(HttpServletResponse.SC_FORBIDDEN, isPermanentBan
+                            ? "영구적으로 차단된 계정입니다."
+                            : "정지된 계정입니다. (해제 예정일: " + user.getBannedUntil() + ")");
                     response.flushBuffer();
                     return;
                 }

--- a/src/main/java/com/back/report/controller/AdminReportController.java
+++ b/src/main/java/com/back/report/controller/AdminReportController.java
@@ -1,0 +1,44 @@
+package com.back.report.controller;
+
+import com.back.report.dto.ReportResponse;
+import com.back.report.dto.ReportedContentResponse;
+import com.back.report.service.ReportAdminService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class AdminReportController {
+
+    private final ReportAdminService reportAdminService;
+
+    // 특정 회원이 받은 신고 내역 전체 (제재회원 관리 화면3)
+    @GetMapping("/api/admin/reports/users/{userId}")
+    public ResponseEntity<List<ReportedContentResponse>> getReportsByTargetAuthor(@PathVariable Long userId) {
+        log.info("회원별 신고 내역 조회 요청 - userId: {}", userId);
+        return ResponseEntity.ok(reportAdminService.getReportsByTargetAuthor(userId));
+    }
+
+    // 신고 수락 (삭제 처리 + 작성자 주의 포인트 자동 부여)
+    @PostMapping("/api/admin/reports/{reportId}/resolve")
+    public ResponseEntity<ReportResponse> resolveReport(@PathVariable Long reportId) {
+        Long adminUserId = Long.parseLong(SecurityContextHolder.getContext().getAuthentication().getName());
+        log.info("신고 수락 처리 요청 - reportId: {}, 처리 관리자: {}", reportId, adminUserId);
+        reportAdminService.resolveReport(reportId, adminUserId);
+        return ResponseEntity.ok(new ReportResponse("신고를 수락하여 삭제 처리했습니다."));
+    }
+
+    // 신고 거절
+    @PostMapping("/api/admin/reports/{reportId}/reject")
+    public ResponseEntity<ReportResponse> rejectReport(@PathVariable Long reportId) {
+        log.info("신고 거절 처리 요청 - reportId: {}", reportId);
+        reportAdminService.rejectReport(reportId);
+        return ResponseEntity.ok(new ReportResponse("신고를 거절했습니다."));
+    }
+}

--- a/src/main/java/com/back/report/controller/ReportController.java
+++ b/src/main/java/com/back/report/controller/ReportController.java
@@ -1,0 +1,27 @@
+package com.back.report.controller;
+
+import com.back.report.dto.ReportRequest;
+import com.back.report.dto.ReportResponse;
+import com.back.report.service.ReportService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class ReportController {
+
+    private final ReportService reportService;
+
+    // 게시글/댓글 신고 접수
+    @PostMapping("/api/stu/reports")
+    public ResponseEntity<ReportResponse> submitReport(@RequestBody ReportRequest request) {
+        log.info("신고 접수 요청 - targetType: {}, targetId: {}", request.getTargetType(), request.getTargetId());
+        reportService.submitReport(request);
+        return ResponseEntity.ok(new ReportResponse("신고가 접수되었습니다."));
+    }
+}

--- a/src/main/java/com/back/report/dto/ReportDto.java
+++ b/src/main/java/com/back/report/dto/ReportDto.java
@@ -1,0 +1,17 @@
+package com.back.report.dto;
+
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+public class ReportDto {
+    private Long reportId;
+    private Long reporterId;
+    private String targetType;
+    private Long targetId;
+    private Long reasonId;
+    private String detail;
+    private String status;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/back/report/dto/ReportRequest.java
+++ b/src/main/java/com/back/report/dto/ReportRequest.java
@@ -1,0 +1,11 @@
+package com.back.report.dto;
+
+import lombok.Data;
+
+@Data
+public class ReportRequest {
+    private String targetType; // post / comment
+    private Long targetId;
+    private Long reasonId;
+    private String detail;
+}

--- a/src/main/java/com/back/report/dto/ReportResponse.java
+++ b/src/main/java/com/back/report/dto/ReportResponse.java
@@ -1,0 +1,14 @@
+package com.back.report.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ReportResponse {
+    private String message;
+}

--- a/src/main/java/com/back/report/dto/ReportedContentResponse.java
+++ b/src/main/java/com/back/report/dto/ReportedContentResponse.java
@@ -1,0 +1,22 @@
+package com.back.report.dto;
+
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+public class ReportedContentResponse {
+    private Long reportId;
+    private String targetType;
+    private Long targetId;
+    private Long postId;
+    private Long boardId;
+    private String boardCode;
+    private Long reasonId;
+    private String reasonLabel;
+    private String detail;
+    private String status;
+    private Integer activeFlag;
+    private LocalDateTime createdAt;
+    private LocalDateTime resolvedAt;
+}

--- a/src/main/java/com/back/report/exception/ReportException.java
+++ b/src/main/java/com/back/report/exception/ReportException.java
@@ -1,0 +1,11 @@
+package com.back.report.exception;
+
+import com.back.global.exception.BaseException;
+import org.springframework.http.HttpStatus;
+
+public class ReportException extends BaseException {
+
+    public ReportException(String message, HttpStatus status) {
+        super(message, status);
+    }
+}

--- a/src/main/java/com/back/report/mapper/ReportMapper.java
+++ b/src/main/java/com/back/report/mapper/ReportMapper.java
@@ -1,0 +1,40 @@
+package com.back.report.mapper;
+
+import com.back.report.dto.ReportDto;
+import com.back.report.dto.ReportedContentResponse;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+
+@Mapper
+public interface ReportMapper {
+
+    // 신고 접수
+    void insertReport(@Param("reporterId") Long reporterId,
+                       @Param("targetType") String targetType,
+                       @Param("targetId") Long targetId,
+                       @Param("reasonId") Long reasonId,
+                       @Param("detail") String detail);
+
+    // 신고 단건 조회 (수락/거절 처리 전 상태 확인용)
+    ReportDto findReportById(@Param("reportId") Long reportId);
+
+    // 게시글/댓글은 board 도메인에 상관없이 posts/comments 테이블을 직접 참조 (신고 대상은 자유/정보게시판 어디든 될 수 있음)
+    Long findPostAuthorId(@Param("postId") Long postId);
+    Long findCommentAuthorId(@Param("commentId") Long commentId);
+    int softDeletePost(@Param("postId") Long postId);
+    int softDeleteComment(@Param("commentId") Long commentId);
+
+    // 신고 수락(삭제 처리) - moderation_log 액션과 연결
+    void resolveReport(@Param("reportId") Long reportId, @Param("resolutionActionId") Long resolutionActionId);
+
+    // 신고 거절
+    void rejectReport(@Param("reportId") Long reportId);
+
+    // 특정 회원이 작성한 게시글/댓글이 받은 신고 내역 전체
+    List<ReportedContentResponse> findReportsByTargetAuthor(@Param("userId") Long userId);
+
+    // 신고가 수락(삭제 처리)된 건수 - 제재회원 현황 화면용
+    int countResolvedDeletionsByUser(@Param("userId") Long userId);
+}

--- a/src/main/java/com/back/report/service/ReportAdminService.java
+++ b/src/main/java/com/back/report/service/ReportAdminService.java
@@ -1,0 +1,66 @@
+package com.back.report.service;
+
+import com.back.report.dto.ReportDto;
+import com.back.report.dto.ReportedContentResponse;
+import com.back.report.exception.ReportException;
+import com.back.report.mapper.ReportMapper;
+import com.back.sanction.service.PenaltyService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ReportAdminService {
+
+    private final ReportMapper reportMapper;
+    private final PenaltyService penaltyService;
+
+    // 특정 회원이 작성한 게시글/댓글이 받은 신고 내역 전체
+    public List<ReportedContentResponse> getReportsByTargetAuthor(Long userId) {
+        return reportMapper.findReportsByTargetAuthor(userId);
+    }
+
+    // 신고 수락: 대상 소프트 삭제 + 작성자 주의 포인트 부여 + 신고 처리 결과 연결
+    @Transactional
+    public void resolveReport(Long reportId, Long adminUserId) {
+        ReportDto report = getPendingReportOrThrow(reportId);
+
+        Long authorId;
+        if ("post".equals(report.getTargetType())) {
+            authorId = reportMapper.findPostAuthorId(report.getTargetId());
+            if (authorId == null) throw new ReportException("존재하지 않는 게시글입니다.", HttpStatus.NOT_FOUND);
+            reportMapper.softDeletePost(report.getTargetId());
+        } else {
+            authorId = reportMapper.findCommentAuthorId(report.getTargetId());
+            if (authorId == null) throw new ReportException("존재하지 않는 댓글입니다.", HttpStatus.NOT_FOUND);
+            reportMapper.softDeleteComment(report.getTargetId());
+        }
+
+        Long actionId = penaltyService.applyDeletionPenalty(authorId, report.getTargetType(), report.getTargetId(),
+                report.getReasonId(), report.getDetail(), adminUserId);
+
+        reportMapper.resolveReport(reportId, actionId);
+    }
+
+    // 신고 거절: 삭제/패널티 없이 신고만 종료
+    @Transactional
+    public void rejectReport(Long reportId) {
+        getPendingReportOrThrow(reportId);
+        reportMapper.rejectReport(reportId);
+    }
+
+    private ReportDto getPendingReportOrThrow(Long reportId) {
+        ReportDto report = reportMapper.findReportById(reportId);
+        if (report == null) {
+            throw new ReportException("존재하지 않는 신고입니다.", HttpStatus.NOT_FOUND);
+        }
+        if (!"pending".equals(report.getStatus())) {
+            throw new ReportException("이미 처리된 신고입니다.", HttpStatus.CONFLICT);
+        }
+        return report;
+    }
+}

--- a/src/main/java/com/back/report/service/ReportService.java
+++ b/src/main/java/com/back/report/service/ReportService.java
@@ -1,0 +1,52 @@
+package com.back.report.service;
+
+import com.back.report.dto.ReportRequest;
+import com.back.report.exception.ReportException;
+import com.back.report.mapper.ReportMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ReportService {
+
+    private final ReportMapper reportMapper;
+
+    private Long getCurrentUserId() {
+        String subValue = SecurityContextHolder.getContext().getAuthentication().getName();
+        try {
+            return Long.parseLong(subValue);
+        } catch (NumberFormatException e) {
+            throw new ReportException("로그인이 필요한 서비스입니다.", HttpStatus.UNAUTHORIZED);
+        }
+    }
+
+    // 게시글/댓글 신고 접수
+    @Transactional
+    public void submitReport(ReportRequest request) {
+        Long reporterId = getCurrentUserId();
+
+        if (!"post".equals(request.getTargetType()) && !"comment".equals(request.getTargetType())) {
+            throw new ReportException("targetType은 post 또는 comment여야 합니다.", HttpStatus.BAD_REQUEST);
+        }
+
+        Long authorId = "post".equals(request.getTargetType())
+                ? reportMapper.findPostAuthorId(request.getTargetId())
+                : reportMapper.findCommentAuthorId(request.getTargetId());
+        if (authorId == null) {
+            throw new ReportException("존재하지 않는 게시글/댓글입니다.", HttpStatus.NOT_FOUND);
+        }
+
+        try {
+            reportMapper.insertReport(reporterId, request.getTargetType(), request.getTargetId(),
+                    request.getReasonId(), request.getDetail());
+        } catch (DuplicateKeyException e) {
+            // reports_log의 uq_reports_active(reporter_id, target_type, target_id, active_flag) 유니크 제약 위반
+            throw new ReportException("이미 신고한 게시글/댓글입니다.", HttpStatus.CONFLICT);
+        }
+    }
+}

--- a/src/main/java/com/back/sanction/controller/AdminSanctionController.java
+++ b/src/main/java/com/back/sanction/controller/AdminSanctionController.java
@@ -1,0 +1,44 @@
+package com.back.sanction.controller;
+
+import com.back.sanction.dto.SanctionResponse;
+import com.back.sanction.dto.SanctionedUserDetailResponse;
+import com.back.sanction.dto.SanctionedUserResponse;
+import com.back.sanction.service.SanctionAdminService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class AdminSanctionController {
+
+    private final SanctionAdminService sanctionAdminService;
+
+    // 현재 제재(정지/영구차단) 중인 회원 목록
+    @GetMapping("/api/admin/sanctions/users")
+    public ResponseEntity<List<SanctionedUserResponse>> getSanctionedUsers() {
+        log.info("제재 회원 목록 조회 요청");
+        return ResponseEntity.ok(sanctionAdminService.getSanctionedUsers());
+    }
+
+    // 특정 회원의 현재 제재 현황
+    @GetMapping("/api/admin/sanctions/users/{userId}")
+    public ResponseEntity<SanctionedUserDetailResponse> getSanctionedUserDetail(@PathVariable Long userId) {
+        log.info("제재 회원 현황 조회 요청 - userId: {}", userId);
+        return ResponseEntity.ok(sanctionAdminService.getSanctionedUserDetail(userId));
+    }
+
+    // 관리자 수동 제재 해제
+    @PostMapping("/api/admin/sanctions/users/{userId}/lift")
+    public ResponseEntity<SanctionResponse> liftBan(@PathVariable Long userId) {
+        Long adminUserId = Long.parseLong(SecurityContextHolder.getContext().getAuthentication().getName());
+        log.info("제재 해제 요청 - 대상 userId: {}, 처리 관리자: {}", userId, adminUserId);
+        sanctionAdminService.liftBan(userId, adminUserId);
+        return ResponseEntity.ok(new SanctionResponse("제재가 해제되었습니다."));
+    }
+}

--- a/src/main/java/com/back/sanction/dto/BanPolicyDto.java
+++ b/src/main/java/com/back/sanction/dto/BanPolicyDto.java
@@ -1,0 +1,13 @@
+package com.back.sanction.dto;
+
+import lombok.Data;
+
+@Data
+public class BanPolicyDto {
+    private Long banPolicyId;
+    private String code;
+    private Integer warningNo;
+    private String banType;
+    private Integer banDays;
+    private String description;
+}

--- a/src/main/java/com/back/sanction/dto/ModerationLogDto.java
+++ b/src/main/java/com/back/sanction/dto/ModerationLogDto.java
@@ -1,0 +1,14 @@
+package com.back.sanction.dto;
+
+import lombok.Data;
+
+@Data
+public class ModerationLogDto {
+    private Long actionId;
+    private String targetType;
+    private Long targetId;
+    private String appliedState;
+    private Long reasonId;
+    private String detail;
+    private Long actedBy;
+}

--- a/src/main/java/com/back/sanction/dto/PenaltyLogDto.java
+++ b/src/main/java/com/back/sanction/dto/PenaltyLogDto.java
@@ -1,0 +1,16 @@
+package com.back.sanction.dto;
+
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+public class PenaltyLogDto {
+    private Long penaltyId;
+    private Long userId;
+    private Integer points;
+    private String targetType;
+    private Long targetId;
+    private Long sourceActionId;
+    private LocalDateTime expiresAt;
+}

--- a/src/main/java/com/back/sanction/dto/SanctionResponse.java
+++ b/src/main/java/com/back/sanction/dto/SanctionResponse.java
@@ -1,0 +1,14 @@
+package com.back.sanction.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class SanctionResponse {
+    private String message;
+}

--- a/src/main/java/com/back/sanction/dto/SanctionedUserDetailResponse.java
+++ b/src/main/java/com/back/sanction/dto/SanctionedUserDetailResponse.java
@@ -1,0 +1,21 @@
+package com.back.sanction.dto;
+
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+public class SanctionedUserDetailResponse {
+    // 회원 태그: caution(주의) / temporary(정지) / permanent(차단) / none
+    private String tag;
+    private String banStatus;
+    private LocalDateTime bannedUntil;
+    private LocalDateTime banStartedAt;
+
+    // 누적주의: 현재 유효한 주의 포인트 합계 % caution_per_warning (다음 경고까지 남은 주의 아님, 스펙에 명시된 계산식 그대로)
+    private Integer cautionRemainder;
+    // 누적경고: 현재 유효한 경고 개수
+    private Integer warningCount;
+    // 신고가 수락(삭제 처리)되어 반영된 건수
+    private Integer reportDeletedCount;
+}

--- a/src/main/java/com/back/sanction/dto/SanctionedUserResponse.java
+++ b/src/main/java/com/back/sanction/dto/SanctionedUserResponse.java
@@ -1,0 +1,19 @@
+package com.back.sanction.dto;
+
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+public class SanctionedUserResponse {
+    private Long userId;
+    private String loginId;
+    private String name;
+    private String email;
+    private String banStatus;
+    private LocalDateTime bannedUntil;
+    private LocalDateTime banStartedAt;
+
+    // 회원 태그: caution(주의) / temporary(정지) / permanent(차단)
+    private String tag;
+}

--- a/src/main/java/com/back/sanction/exception/SanctionException.java
+++ b/src/main/java/com/back/sanction/exception/SanctionException.java
@@ -1,0 +1,11 @@
+package com.back.sanction.exception;
+
+import com.back.global.exception.BaseException;
+import org.springframework.http.HttpStatus;
+
+public class SanctionException extends BaseException {
+
+    public SanctionException(String message, HttpStatus status) {
+        super(message, status);
+    }
+}

--- a/src/main/java/com/back/sanction/mapper/SanctionMapper.java
+++ b/src/main/java/com/back/sanction/mapper/SanctionMapper.java
@@ -1,0 +1,60 @@
+package com.back.sanction.mapper;
+
+import com.back.sanction.dto.BanPolicyDto;
+import com.back.sanction.dto.ModerationLogDto;
+import com.back.sanction.dto.PenaltyLogDto;
+import com.back.sanction.dto.SanctionedUserResponse;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Mapper
+public interface SanctionMapper {
+
+    // 조치 이력(append-only) 기록 - 삭제/복원 등. 생성된 actionId는 dto.actionId로 채워짐
+    void insertModerationLog(ModerationLogDto dto);
+
+    // 주의 포인트 원장 기록
+    void insertPenaltyLog(PenaltyLogDto dto);
+
+    // 현재 유효한(회수되지 않고 만료되지 않은) 주의 포인트 합계
+    int sumValidCautionPoints(@Param("userId") Long userId);
+
+    // 경고 원장 기록
+    void insertWarningLog(@Param("userId") Long userId, @Param("expiresAt") LocalDateTime expiresAt);
+
+    // 현재 유효한(만료되지 않은) 경고 개수
+    int countValidWarnings(@Param("userId") Long userId);
+
+    // 몇 번째 경고에 어떤 차단이 적용되는지 정책 조회
+    BanPolicyDto findBanPolicyByWarningNo(@Param("warningNo") int warningNo);
+
+    // 차단 이력 기록
+    void insertBanLog(@Param("userId") Long userId,
+                       @Param("warningNo") int warningNo,
+                       @Param("banType") String banType,
+                       @Param("startsAt") LocalDateTime startsAt,
+                       @Param("endsAt") LocalDateTime endsAt);
+
+    // users 캐시 컬럼(ban_status/banned_until) 갱신
+    void updateUserBanStatus(@Param("userId") Long userId,
+                              @Param("banStatus") String banStatus,
+                              @Param("bannedUntil") LocalDateTime bannedUntil);
+
+    // 정책 수치 조회 (policy_settings.code -> setting_value)
+    String findPolicySetting(@Param("code") String code);
+
+    // 현재 제재 중인 회원 목록 (관리자 페이지용)
+    List<SanctionedUserResponse> findSanctionedUsers();
+
+    // 특정 회원의 태그/제재 정보 단건 조회
+    SanctionedUserResponse findSanctionedUserById(@Param("userId") Long userId);
+
+    // 활성 상태인 최신 ban_log 행을 해제 처리 (liftedBy가 null이면 시스템 자동 해제)
+    void closeActiveBanLog(@Param("userId") Long userId, @Param("liftedBy") Long liftedBy);
+
+    // 만료된 임시정지 대상 유저 ID 목록 (스케줄러용)
+    List<Long> findExpiredTemporaryBanUserIds();
+}

--- a/src/main/java/com/back/sanction/service/BanExpiryScheduler.java
+++ b/src/main/java/com/back/sanction/service/BanExpiryScheduler.java
@@ -1,0 +1,33 @@
+package com.back.sanction.service;
+
+import com.back.sanction.mapper.SanctionMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class BanExpiryScheduler {
+
+    private final SanctionMapper sanctionMapper;
+
+    // 매시간 만료된 임시정지의 ban_status 캐시를 정리 (로그인 판정 자체는 항상 banned_until 실시간 비교가 기준이라
+    // 이 스케줄러가 늦게 돌아도 만료된 유저의 로그인은 이미 허용됨 - 이건 관리자 페이지용 캐시 정리 목적)
+    @Scheduled(cron = "0 0 * * * *")
+    @Transactional
+    public void liftExpiredTemporaryBans() {
+        List<Long> expiredUserIds = sanctionMapper.findExpiredTemporaryBanUserIds();
+        for (Long userId : expiredUserIds) {
+            sanctionMapper.updateUserBanStatus(userId, "none", null);
+            sanctionMapper.closeActiveBanLog(userId, null);
+        }
+        if (!expiredUserIds.isEmpty()) {
+            log.info("만료된 임시정지 {}건 자동 해제 완료", expiredUserIds.size());
+        }
+    }
+}

--- a/src/main/java/com/back/sanction/service/PenaltyService.java
+++ b/src/main/java/com/back/sanction/service/PenaltyService.java
@@ -1,0 +1,90 @@
+package com.back.sanction.service;
+
+import com.back.sanction.dto.BanPolicyDto;
+import com.back.sanction.dto.ModerationLogDto;
+import com.back.sanction.dto.PenaltyLogDto;
+import com.back.sanction.mapper.SanctionMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PenaltyService {
+
+    private final SanctionMapper sanctionMapper;
+
+    private static final String DEFAULT_CAUTION_PER_DELETE = "2";
+    private static final String DEFAULT_CAUTION_PER_WARNING = "10";
+    private static final String DEFAULT_CAUTION_TTL_DAYS = "365";
+    private static final String DEFAULT_WARNING_TTL_DAYS = "365";
+
+    private int policyInt(String code, String defaultValue) {
+        String value = sanctionMapper.findPolicySetting(code);
+        return Integer.parseInt(value != null ? value : defaultValue);
+    }
+
+    // 관리자가 게시글/댓글을 직접 삭제했을 때 작성자에게 주의 포인트를 부여하고,
+    // 누적 결과에 따라 경고 전환 -> 정지/영구차단까지 한 번에 처리.
+    // 반환값은 생성된 moderation_log의 actionId (신고 수락 처리 시 reports_log와 연결하기 위함)
+    @Transactional
+    public Long applyDeletionPenalty(Long authorUserId, String targetType, Long targetId,
+                                      Long reasonId, String detail, Long actedByAdminId) {
+        ModerationLogDto moderationLog = new ModerationLogDto();
+        moderationLog.setTargetType(targetType);
+        moderationLog.setTargetId(targetId);
+        moderationLog.setAppliedState("deleted");
+        moderationLog.setReasonId(reasonId);
+        moderationLog.setDetail(detail);
+        moderationLog.setActedBy(actedByAdminId);
+        sanctionMapper.insertModerationLog(moderationLog);
+
+        int cautionPoints = policyInt("caution_per_delete", DEFAULT_CAUTION_PER_DELETE);
+        int cautionPerWarning = policyInt("cautions_per_warning", DEFAULT_CAUTION_PER_WARNING);
+        int cautionTtlDays = policyInt("caution_ttl_days", DEFAULT_CAUTION_TTL_DAYS);
+        int warningTtlDays = policyInt("warning_ttl_days", DEFAULT_WARNING_TTL_DAYS);
+
+        int oldSum = sanctionMapper.sumValidCautionPoints(authorUserId);
+
+        PenaltyLogDto penaltyLog = new PenaltyLogDto();
+        penaltyLog.setUserId(authorUserId);
+        penaltyLog.setPoints(cautionPoints);
+        penaltyLog.setTargetType(targetType);
+        penaltyLog.setTargetId(targetId);
+        penaltyLog.setSourceActionId(moderationLog.getActionId());
+        penaltyLog.setExpiresAt(LocalDateTime.now().plusDays(cautionTtlDays));
+        sanctionMapper.insertPenaltyLog(penaltyLog);
+
+        int newSum = oldSum + cautionPoints;
+        int warningsToIssue = (newSum / cautionPerWarning) - (oldSum / cautionPerWarning);
+
+        for (int i = 0; i < warningsToIssue; i++) {
+            sanctionMapper.insertWarningLog(authorUserId, LocalDateTime.now().plusDays(warningTtlDays));
+            int currentWarningNo = sanctionMapper.countValidWarnings(authorUserId);
+
+            BanPolicyDto policy = sanctionMapper.findBanPolicyByWarningNo(currentWarningNo);
+            if (policy == null) {
+                // 정의된 차단 정책보다 큰 경고 단계(예: 이미 영구차단된 유저)는 추가 조치 없이 무시
+                log.info("경고 {}회 도달, 매칭되는 차단 정책 없음 (userId={})", currentWarningNo, authorUserId);
+                continue;
+            }
+
+            LocalDateTime startsAt = LocalDateTime.now();
+            LocalDateTime endsAt = "permanent".equals(policy.getBanType())
+                    ? null
+                    : startsAt.plusDays(policy.getBanDays());
+
+            sanctionMapper.insertBanLog(authorUserId, policy.getWarningNo(), policy.getBanType(), startsAt, endsAt);
+            sanctionMapper.updateUserBanStatus(authorUserId, policy.getBanType(), endsAt);
+
+            log.warn("유저 {} 제재 적용 - 경고 {}회, banType={}, endsAt={}",
+                    authorUserId, currentWarningNo, policy.getBanType(), endsAt);
+        }
+
+        return moderationLog.getActionId();
+    }
+}

--- a/src/main/java/com/back/sanction/service/SanctionAdminService.java
+++ b/src/main/java/com/back/sanction/service/SanctionAdminService.java
@@ -1,0 +1,59 @@
+package com.back.sanction.service;
+
+import com.back.report.mapper.ReportMapper;
+import com.back.sanction.dto.SanctionedUserDetailResponse;
+import com.back.sanction.dto.SanctionedUserResponse;
+import com.back.sanction.exception.SanctionException;
+import com.back.sanction.mapper.SanctionMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SanctionAdminService {
+
+    private final SanctionMapper sanctionMapper;
+    private final ReportMapper reportMapper;
+
+    private static final String DEFAULT_CAUTION_PER_WARNING = "10";
+
+    // 현재 제재(정지/영구차단/주의) 중인 회원 목록
+    public List<SanctionedUserResponse> getSanctionedUsers() {
+        return sanctionMapper.findSanctionedUsers();
+    }
+
+    // 특정 회원의 현재 제재 현황 (태그, 정지 기간, 누적주의, 누적경고, 신고삭제처리건수)
+    public SanctionedUserDetailResponse getSanctionedUserDetail(Long userId) {
+        SanctionedUserResponse base = sanctionMapper.findSanctionedUserById(userId);
+        if (base == null) {
+            throw new SanctionException("존재하지 않는 회원입니다.", HttpStatus.NOT_FOUND);
+        }
+
+        String cautionPerWarningSetting = sanctionMapper.findPolicySetting("cautions_per_warning");
+        int cautionPerWarning = Integer.parseInt(
+                cautionPerWarningSetting != null ? cautionPerWarningSetting : DEFAULT_CAUTION_PER_WARNING);
+        int cautionSum = sanctionMapper.sumValidCautionPoints(userId);
+
+        SanctionedUserDetailResponse detail = new SanctionedUserDetailResponse();
+        detail.setTag(base.getTag());
+        detail.setBanStatus(base.getBanStatus());
+        detail.setBannedUntil(base.getBannedUntil());
+        detail.setBanStartedAt(base.getBanStartedAt());
+        detail.setCautionRemainder(cautionSum % cautionPerWarning);
+        detail.setWarningCount(sanctionMapper.countValidWarnings(userId));
+        detail.setReportDeletedCount(reportMapper.countResolvedDeletionsByUser(userId));
+        return detail;
+    }
+
+    // 관리자 수동 해제
+    @Transactional
+    public void liftBan(Long userId, Long adminUserId) {
+        sanctionMapper.updateUserBanStatus(userId, "none", null);
+        sanctionMapper.closeActiveBanLog(userId, adminUserId);
+    }
+}

--- a/src/main/java/com/back/student/free/controller/FreeController.java
+++ b/src/main/java/com/back/student/free/controller/FreeController.java
@@ -111,4 +111,24 @@ public class FreeController {
         log.info("자게 댓글 삭제 요청 - 댓글 ID: {}", commentId);
         return ResponseEntity.ok(freeService.deleteComment(commentId));
     }
+
+    // 관리자 강제 게시글 삭제 (작성자에게 주의 포인트 자동 부여)
+    @DeleteMapping("/api/admin/free/posts/{postId}")
+    public ResponseEntity<FreeResponse> deletePostByAdmin(
+            @PathVariable Long postId,
+            @RequestParam(required = false) Long reasonId,
+            @RequestParam(required = false) String detail) {
+        log.info("관리자 자유게시글 강제 삭제 요청 - ID: {}", postId);
+        return ResponseEntity.ok(freeService.deletePostByAdmin(postId, reasonId, detail));
+    }
+
+    // 관리자 강제 댓글 삭제 (작성자에게 주의 포인트 자동 부여)
+    @DeleteMapping("/api/admin/free/posts/{postId}/comments/{commentId}")
+    public ResponseEntity<FreeResponse> deleteCommentByAdmin(
+            @PathVariable Long commentId,
+            @RequestParam(required = false) Long reasonId,
+            @RequestParam(required = false) String detail) {
+        log.info("관리자 자게 댓글 강제 삭제 요청 - 댓글 ID: {}", commentId);
+        return ResponseEntity.ok(freeService.deleteCommentByAdmin(commentId, reasonId, detail));
+    }
 }

--- a/src/main/java/com/back/student/free/mapper/FreeMapper.java
+++ b/src/main/java/com/back/student/free/mapper/FreeMapper.java
@@ -68,6 +68,9 @@ public interface FreeMapper {
     // 게시글 삭제
     int deletePost(@Param("postId") Long postId);
 
+    // 관리자 강제 삭제 (소프트 삭제 - state만 'deleted'로 전환)
+    int softDeletePost(@Param("postId") Long postId);
+
     // 첨부파일 정보 DB 등록
     void insertAttachment(
             @Param("postId") Long postId,
@@ -93,4 +96,7 @@ public interface FreeMapper {
 
     // 댓글 삭제
     void deleteComment(@Param("commentId") Long commentId);
+
+    // 관리자 강제 삭제 (소프트 삭제 - state만 'deleted'로 전환)
+    int softDeleteComment(@Param("commentId") Long commentId);
 }

--- a/src/main/java/com/back/student/free/service/FreeService.java
+++ b/src/main/java/com/back/student/free/service/FreeService.java
@@ -24,8 +24,14 @@ public interface FreeService {
     FreeResponse updatePost(Long postId, FreeUpdateRequest request);
     FreeResponse deletePost(Long postId);
 
+    // 관리자 강제 삭제 (소프트 삭제 + 작성자 주의 포인트 부여)
+    FreeResponse deletePostByAdmin(Long postId, Long reasonId, String detail);
+
     // 댓글 등록, 수정, 삭제
     CommentResponse createComment(Long postId, CommentRequest request);
     CommentResponse updateComment(Long commentId, CommentRequest request);
     FreeResponse deleteComment(Long commentId);
+
+    // 관리자 강제 삭제 (소프트 삭제 + 작성자 주의 포인트 부여)
+    FreeResponse deleteCommentByAdmin(Long commentId, Long reasonId, String detail);
 }

--- a/src/main/java/com/back/student/free/service/FreeServiceImpl.java
+++ b/src/main/java/com/back/student/free/service/FreeServiceImpl.java
@@ -1,5 +1,6 @@
 package com.back.student.free.service;
 
+import com.back.sanction.service.PenaltyService;
 import com.back.student.common.FileStorageUtil;
 import com.back.student.free.dto.*; // Free 패키지의 DTO들 임포트
 import com.back.student.free.exception.FreeException;
@@ -23,6 +24,7 @@ public class FreeServiceImpl implements FreeService {
 
     private final FreeMapper freeMapper;
     private final FileStorageUtil fileStorageUtil;
+    private final PenaltyService penaltyService;
     private final Long FREE_BOARD_ID = 2L; // 자유게시판 고유 ID 2번 고정
 
     // 현재 로그인한 사용자의 고유 ID(PK) 추출 (토큰이 없거나 유효하지 않으면 여기서 차단)
@@ -199,6 +201,25 @@ public class FreeServiceImpl implements FreeService {
         return new FreeResponse("자게가 성공적으로 삭제되었습니다.");
     }
 
+    // 관리자 강제 삭제: 소프트 삭제 처리 후 작성자에게 주의 포인트 부여
+    @Override
+    @Transactional
+    public FreeResponse deletePostByAdmin(Long postId, Long reasonId, String detail) {
+        Long adminUserId = getCurrentUserId();
+        if (!isAdmin()) {
+            throw new FreeException("관리자만 삭제할 수 있습니다.", HttpStatus.FORBIDDEN);
+        }
+
+        Long authorId = freeMapper.findAuthorIdByPostId(postId);
+        if (authorId == null) {
+            throw new FreeException("존재하지 않는 게시글입니다.", HttpStatus.NOT_FOUND);
+        }
+
+        freeMapper.softDeletePost(postId);
+        penaltyService.applyDeletionPenalty(authorId, "post", postId, reasonId, detail, adminUserId);
+        return new FreeResponse("게시글이 관리자에 의해 삭제되었습니다.");
+    }
+
     // 게시글에 대한 댓글 신규 등록
     @Override
     @Transactional
@@ -236,5 +257,24 @@ public class FreeServiceImpl implements FreeService {
 
         freeMapper.deleteComment(commentId);
         return new FreeResponse("댓글이 성공적으로 삭제되었습니다.");
+    }
+
+    // 관리자 강제 삭제: 소프트 삭제 처리 후 작성자에게 주의 포인트 부여
+    @Override
+    @Transactional
+    public FreeResponse deleteCommentByAdmin(Long commentId, Long reasonId, String detail) {
+        Long adminUserId = getCurrentUserId();
+        if (!isAdmin()) {
+            throw new FreeException("관리자만 삭제할 수 있습니다.", HttpStatus.FORBIDDEN);
+        }
+
+        Long authorId = freeMapper.findCommentAuthorId(commentId);
+        if (authorId == null) {
+            throw new FreeException("존재하지 않는 댓글입니다.", HttpStatus.NOT_FOUND);
+        }
+
+        freeMapper.softDeleteComment(commentId);
+        penaltyService.applyDeletionPenalty(authorId, "comment", commentId, reasonId, detail, adminUserId);
+        return new FreeResponse("댓글이 관리자에 의해 삭제되었습니다.");
     }
 }

--- a/src/main/java/com/back/student/info/controller/InfoController.java
+++ b/src/main/java/com/back/student/info/controller/InfoController.java
@@ -111,4 +111,24 @@ public class InfoController {
         log.info("정게 댓글 삭제 요청 - 댓글 ID: {}", commentId);
         return ResponseEntity.ok(infoService.deleteComment(commentId));
     }
+
+    // 관리자 강제 게시글 삭제 (작성자에게 주의 포인트 자동 부여)
+    @DeleteMapping("/api/admin/info/posts/{postId}")
+    public ResponseEntity<InfoResponse> deletePostByAdmin(
+            @PathVariable Long postId,
+            @RequestParam(required = false) Long reasonId,
+            @RequestParam(required = false) String detail) {
+        log.info("관리자 정보게시글 강제 삭제 요청 - ID: {}", postId);
+        return ResponseEntity.ok(infoService.deletePostByAdmin(postId, reasonId, detail));
+    }
+
+    // 관리자 강제 댓글 삭제 (작성자에게 주의 포인트 자동 부여)
+    @DeleteMapping("/api/admin/info/posts/{postId}/comments/{commentId}")
+    public ResponseEntity<InfoResponse> deleteCommentByAdmin(
+            @PathVariable Long commentId,
+            @RequestParam(required = false) Long reasonId,
+            @RequestParam(required = false) String detail) {
+        log.info("관리자 정게 댓글 강제 삭제 요청 - 댓글 ID: {}", commentId);
+        return ResponseEntity.ok(infoService.deleteCommentByAdmin(commentId, reasonId, detail));
+    }
 }

--- a/src/main/java/com/back/student/info/mapper/InfoMapper.java
+++ b/src/main/java/com/back/student/info/mapper/InfoMapper.java
@@ -68,6 +68,9 @@ public interface InfoMapper {
     // 게시글 삭제
     int deletePost(@Param("postId") Long postId);
 
+    // 관리자 강제 삭제 (소프트 삭제 - state만 'deleted'로 전환)
+    int softDeletePost(@Param("postId") Long postId);
+
     // 첨부파일 정보 DB 등록
     void insertAttachment(
             @Param("postId") Long postId,
@@ -93,4 +96,7 @@ public interface InfoMapper {
 
     // 댓글 삭제
     void deleteComment(@Param("commentId") Long commentId);
+
+    // 관리자 강제 삭제 (소프트 삭제 - state만 'deleted'로 전환)
+    int softDeleteComment(@Param("commentId") Long commentId);
 }

--- a/src/main/java/com/back/student/info/service/InfoService.java
+++ b/src/main/java/com/back/student/info/service/InfoService.java
@@ -24,8 +24,14 @@ public interface InfoService {
     InfoResponse updatePost(Long postId, InfoUpdateRequest request);
     InfoResponse deletePost(Long postId);
 
+    // 관리자 강제 삭제 (소프트 삭제 + 작성자 주의 포인트 부여)
+    InfoResponse deletePostByAdmin(Long postId, Long reasonId, String detail);
+
     // 댓글 등록, 수정, 삭제
     CommentResponse createComment(Long postId, CommentRequest request);
     CommentResponse updateComment(Long commentId, CommentRequest request);
     InfoResponse deleteComment(Long commentId);
+
+    // 관리자 강제 삭제 (소프트 삭제 + 작성자 주의 포인트 부여)
+    InfoResponse deleteCommentByAdmin(Long commentId, Long reasonId, String detail);
 }

--- a/src/main/java/com/back/student/info/service/InfoServiceImpl.java
+++ b/src/main/java/com/back/student/info/service/InfoServiceImpl.java
@@ -1,5 +1,6 @@
 package com.back.student.info.service;
 
+import com.back.sanction.service.PenaltyService;
 import com.back.student.common.FileStorageUtil;
 import com.back.student.info.dto.*;
 import com.back.student.info.exception.InfoException;
@@ -23,6 +24,7 @@ public class InfoServiceImpl implements InfoService {
 
     private final InfoMapper infoMapper;
     private final FileStorageUtil fileStorageUtil;
+    private final PenaltyService penaltyService;
     private final Long INFO_BOARD_ID = 3L; // 정보게시판 고유 ID
 
     // 현재 로그인한 사용자의 고유 ID(PK) 추출
@@ -195,6 +197,25 @@ public class InfoServiceImpl implements InfoService {
         return new InfoResponse("정보게시글이 성공적으로 삭제되었습니다.");
     }
 
+    // 관리자 강제 삭제: 소프트 삭제 처리 후 작성자에게 주의 포인트 부여
+    @Override
+    @Transactional
+    public InfoResponse deletePostByAdmin(Long postId, Long reasonId, String detail) {
+        Long adminUserId = getCurrentUserId();
+        if (!isAdmin()) {
+            throw new InfoException("관리자만 삭제할 수 있습니다.", HttpStatus.FORBIDDEN);
+        }
+
+        Long authorId = infoMapper.findAuthorIdByPostId(postId);
+        if (authorId == null) {
+            throw new InfoException("존재하지 않는 게시글입니다.", HttpStatus.NOT_FOUND);
+        }
+
+        infoMapper.softDeletePost(postId);
+        penaltyService.applyDeletionPenalty(authorId, "post", postId, reasonId, detail, adminUserId);
+        return new InfoResponse("게시글이 관리자에 의해 삭제되었습니다.");
+    }
+
     // 정보게시판 댓글 신규 등록 (비밀댓글 기능 포함)
     @Override
     @Transactional
@@ -233,5 +254,24 @@ public class InfoServiceImpl implements InfoService {
 
         infoMapper.deleteComment(commentId);
         return new InfoResponse("댓글이 성공적으로 삭제되었습니다.");
+    }
+
+    // 관리자 강제 삭제: 소프트 삭제 처리 후 작성자에게 주의 포인트 부여
+    @Override
+    @Transactional
+    public InfoResponse deleteCommentByAdmin(Long commentId, Long reasonId, String detail) {
+        Long adminUserId = getCurrentUserId();
+        if (!isAdmin()) {
+            throw new InfoException("관리자만 삭제할 수 있습니다.", HttpStatus.FORBIDDEN);
+        }
+
+        Long authorId = infoMapper.findCommentAuthorId(commentId);
+        if (authorId == null) {
+            throw new InfoException("존재하지 않는 댓글입니다.", HttpStatus.NOT_FOUND);
+        }
+
+        infoMapper.softDeleteComment(commentId);
+        penaltyService.applyDeletionPenalty(authorId, "comment", commentId, reasonId, detail, adminUserId);
+        return new InfoResponse("댓글이 관리자에 의해 삭제되었습니다.");
     }
 }

--- a/src/main/resources/mapper/auth/AuthMapper.xml
+++ b/src/main/resources/mapper/auth/AuthMapper.xml
@@ -12,7 +12,9 @@
                name,
                email,
                role,
-               is_deleted    AS isDeleted
+               is_deleted    AS isDeleted,
+               ban_status    AS banStatus,
+               banned_until  AS bannedUntil
         FROM users
         WHERE login_id = #{loginId}
     </select>

--- a/src/main/resources/mapper/report/ReportMapper.xml
+++ b/src/main/resources/mapper/report/ReportMapper.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.back.report.mapper.ReportMapper">
+
+    <insert id="insertReport">
+        INSERT INTO reports_log (reporter_id, target_type, target_id, reason_id, detail, status, created_at)
+        VALUES (#{reporterId}, #{targetType}, #{targetId}, #{reasonId}, #{detail}, 'pending', NOW())
+    </insert>
+
+    <select id="findReportById" resultType="com.back.report.dto.ReportDto">
+        SELECT report_id   AS reportId,
+               reporter_id AS reporterId,
+               target_type AS targetType,
+               target_id   AS targetId,
+               reason_id   AS reasonId,
+               detail,
+               status,
+               created_at  AS createdAt
+        FROM reports_log
+        WHERE report_id = #{reportId}
+    </select>
+
+    <!-- 신고 대상은 게시판 도메인(free/info)에 상관없이 posts/comments 테이블을 공용으로 사용하므로 직접 조회 -->
+    <select id="findPostAuthorId" resultType="long">
+        SELECT user_id FROM posts WHERE post_id = #{postId}
+    </select>
+
+    <select id="findCommentAuthorId" resultType="long">
+        SELECT user_id FROM comments WHERE comment_id = #{commentId}
+    </select>
+
+    <update id="softDeletePost">
+        UPDATE posts SET state = 'deleted' WHERE post_id = #{postId}
+    </update>
+
+    <update id="softDeleteComment">
+        UPDATE comments SET state = 'deleted' WHERE comment_id = #{commentId}
+    </update>
+
+    <update id="resolveReport">
+        UPDATE reports_log
+        SET status                = 'resolved',
+            resolved_at           = NOW(),
+            resolution_action_id  = #{resolutionActionId}
+        WHERE report_id = #{reportId}
+    </update>
+
+    <update id="rejectReport">
+        UPDATE reports_log
+        SET status      = 'rejected',
+            resolved_at = NOW()
+        WHERE report_id = #{reportId}
+    </update>
+
+    <select id="findReportsByTargetAuthor" resultType="com.back.report.dto.ReportedContentResponse">
+        SELECT
+            r.report_id                                            AS reportId,
+            r.target_type                                          AS targetType,
+            r.target_id                                            AS targetId,
+            CASE WHEN r.target_type = 'post' THEN pb.post_id ELSE c.post_id END AS postId,
+            bd.board_id                                            AS boardId,
+            bd.code                                                AS boardCode,
+            r.reason_id                                            AS reasonId,
+            rs.label                                                AS reasonLabel,
+            r.detail,
+            r.status,
+            r.active_flag                                          AS activeFlag,
+            r.created_at                                           AS createdAt,
+            r.resolved_at                                          AS resolvedAt
+        FROM reports_log r
+        LEFT JOIN posts pb ON r.target_type = 'post' AND r.target_id = pb.post_id
+        LEFT JOIN comments c ON r.target_type = 'comment' AND r.target_id = c.comment_id
+        LEFT JOIN posts cp ON r.target_type = 'comment' AND c.post_id = cp.post_id
+        LEFT JOIN boards bd ON bd.board_id = COALESCE(pb.board_id, cp.board_id)
+        LEFT JOIN reasons rs ON r.reason_id = rs.reason_id
+        WHERE COALESCE(pb.user_id, c.user_id) = #{userId}
+        ORDER BY r.created_at DESC
+    </select>
+
+    <select id="countResolvedDeletionsByUser" resultType="int">
+        SELECT COUNT(*)
+        FROM reports_log r
+        LEFT JOIN posts pb ON r.target_type = 'post' AND r.target_id = pb.post_id
+        LEFT JOIN comments c ON r.target_type = 'comment' AND r.target_id = c.comment_id
+        WHERE COALESCE(pb.user_id, c.user_id) = #{userId}
+          AND r.resolution_action_id IS NOT NULL
+    </select>
+
+</mapper>

--- a/src/main/resources/mapper/sanction/SanctionMapper.xml
+++ b/src/main/resources/mapper/sanction/SanctionMapper.xml
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.back.sanction.mapper.SanctionMapper">
+
+    <insert id="insertModerationLog" useGeneratedKeys="true" keyProperty="actionId">
+        INSERT INTO moderation_log (target_type, target_id, applied_state, reason_id, detail, acted_by, created_at)
+        VALUES (#{targetType}, #{targetId}, #{appliedState}, #{reasonId}, #{detail}, #{actedBy}, NOW())
+    </insert>
+
+    <insert id="insertPenaltyLog">
+        INSERT INTO penalty_log (user_id, points, target_type, target_id, source_action_id, created_at, expires_at)
+        VALUES (#{userId}, #{points}, #{targetType}, #{targetId}, #{sourceActionId}, NOW(), #{expiresAt})
+    </insert>
+
+    <select id="sumValidCautionPoints" resultType="int">
+        SELECT COALESCE(SUM(points), 0)
+        FROM penalty_log
+        WHERE user_id = #{userId}
+          AND voided_at IS NULL
+          AND expires_at > NOW()
+    </select>
+
+    <insert id="insertWarningLog">
+        INSERT INTO warning_log (user_id, created_at, expires_at)
+        VALUES (#{userId}, NOW(), #{expiresAt})
+    </insert>
+
+    <select id="countValidWarnings" resultType="int">
+        SELECT COUNT(*)
+        FROM warning_log
+        WHERE user_id = #{userId}
+          AND expires_at > NOW()
+    </select>
+
+    <select id="findBanPolicyByWarningNo" resultType="com.back.sanction.dto.BanPolicyDto">
+        SELECT ban_policy_id AS banPolicyId,
+               code,
+               warning_no    AS warningNo,
+               ban_type      AS banType,
+               ban_days      AS banDays,
+               description
+        FROM ban_policy
+        WHERE warning_no = #{warningNo}
+    </select>
+
+    <insert id="insertBanLog">
+        INSERT INTO ban_log (user_id, warning_no, ban_type, starts_at, ends_at, created_at)
+        VALUES (#{userId}, #{warningNo}, #{banType}, #{startsAt}, #{endsAt}, NOW())
+    </insert>
+
+    <update id="updateUserBanStatus">
+        UPDATE users
+        SET ban_status   = #{banStatus},
+            banned_until = #{bannedUntil}
+        WHERE user_id = #{userId}
+    </update>
+
+    <select id="findPolicySetting" resultType="string">
+        SELECT setting_value
+        FROM policy_settings
+        WHERE code = #{code}
+    </select>
+
+    <!-- 회원 태그: 차단 > 정지 > 주의(주의 포인트만 있고 정지/차단이 아님) 우선순위로 판정 -->
+    <select id="findSanctionedUsers" resultType="com.back.sanction.dto.SanctionedUserResponse">
+        SELECT u.user_id      AS userId,
+               u.login_id     AS loginId,
+               u.name,
+               u.email,
+               u.ban_status   AS banStatus,
+               u.banned_until AS bannedUntil,
+               (SELECT bl.starts_at FROM ban_log bl
+                 WHERE bl.user_id = u.user_id AND bl.lifted_at IS NULL
+                 ORDER BY bl.created_at DESC LIMIT 1) AS banStartedAt,
+               CASE
+                   WHEN u.ban_status = 'permanent' THEN 'permanent'
+                   WHEN u.ban_status = 'temporary' THEN 'temporary'
+                   ELSE 'caution'
+               END AS tag
+        FROM users u
+        WHERE u.ban_status != 'none'
+           OR EXISTS (
+                SELECT 1 FROM penalty_log pl
+                WHERE pl.user_id = u.user_id
+                  AND pl.voided_at IS NULL
+                  AND pl.expires_at > NOW()
+              )
+        ORDER BY u.user_id DESC
+    </select>
+
+    <select id="findSanctionedUserById" resultType="com.back.sanction.dto.SanctionedUserResponse">
+        SELECT u.user_id      AS userId,
+               u.login_id     AS loginId,
+               u.name,
+               u.email,
+               u.ban_status   AS banStatus,
+               u.banned_until AS bannedUntil,
+               (SELECT bl.starts_at FROM ban_log bl
+                 WHERE bl.user_id = u.user_id AND bl.lifted_at IS NULL
+                 ORDER BY bl.created_at DESC LIMIT 1) AS banStartedAt,
+               CASE
+                   WHEN u.ban_status = 'permanent' THEN 'permanent'
+                   WHEN u.ban_status = 'temporary' THEN 'temporary'
+                   WHEN EXISTS (
+                        SELECT 1 FROM penalty_log pl
+                        WHERE pl.user_id = u.user_id AND pl.voided_at IS NULL AND pl.expires_at > NOW()
+                   ) THEN 'caution'
+                   ELSE 'none'
+               END AS tag
+        FROM users u
+        WHERE u.user_id = #{userId}
+    </select>
+
+    <!-- MySQL은 UPDATE 대상 테이블을 서브쿼리 FROM에서 직접 참조할 수 없어 파생 테이블로 한 번 감쌈 -->
+    <update id="closeActiveBanLog">
+        UPDATE ban_log
+        SET lifted_at = NOW(),
+            lifted_by = #{liftedBy}
+        WHERE ban_id = (
+            SELECT ban_id FROM (
+                SELECT ban_id FROM ban_log
+                WHERE user_id = #{userId} AND lifted_at IS NULL
+                ORDER BY created_at DESC LIMIT 1
+            ) AS latest_active_ban
+        )
+    </update>
+
+    <select id="findExpiredTemporaryBanUserIds" resultType="long">
+        SELECT user_id
+        FROM users
+        WHERE ban_status = 'temporary'
+          AND banned_until &lt;= NOW()
+    </select>
+
+</mapper>

--- a/src/main/resources/mapper/student/FreeMapper.xml
+++ b/src/main/resources/mapper/student/FreeMapper.xml
@@ -15,6 +15,7 @@
                title
         FROM posts
         WHERE board_id = #{boardId}
+          AND state != 'deleted'
         ORDER BY created_at DESC
             LIMIT 5
     </select>
@@ -35,6 +36,7 @@
         INNER JOIN users u ON p.user_id = u.user_id
         LEFT JOIN categories c ON p.category_id = c.category_id
         WHERE p.board_id = #{boardId}
+          AND p.state != 'deleted'
         <if test="categoryId != null">
             AND p.category_id = #{categoryId}
         </if>
@@ -53,6 +55,7 @@
         SELECT COUNT(*)
         FROM posts
         WHERE board_id = #{boardId}
+          AND state != 'deleted'
         <if test="categoryId != null">
             AND category_id = #{categoryId}
         </if>
@@ -82,17 +85,17 @@
         <choose>
             <when test="sort == 'viewCount'">
                 (SELECT post_id FROM posts
-                WHERE board_id = #{boardId} AND post_id != p.post_id
+                WHERE board_id = #{boardId} AND post_id != p.post_id AND state != 'deleted'
                 AND (view_count &gt; p.view_count OR (view_count = p.view_count AND post_id &gt; p.post_id))
                 ORDER BY view_count ASC, post_id ASC LIMIT 1) AS prevPostApi,
                 (SELECT post_id FROM posts
-                WHERE board_id = #{boardId} AND post_id != p.post_id
+                WHERE board_id = #{boardId} AND post_id != p.post_id AND state != 'deleted'
                 AND (view_count &lt; p.view_count OR (view_count = p.view_count AND post_id &lt; p.post_id))
                 ORDER BY view_count DESC, post_id DESC LIMIT 1) AS nextPostApi
             </when>
             <otherwise>
-                (SELECT MAX(post_id) FROM posts WHERE board_id = #{boardId} AND post_id &lt; #{postId}) AS prevPostApi,
-                (SELECT MIN(post_id) FROM posts WHERE board_id = #{boardId} AND post_id &gt; #{postId}) AS nextPostApi
+                (SELECT MAX(post_id) FROM posts WHERE board_id = #{boardId} AND post_id &lt; #{postId} AND state != 'deleted') AS prevPostApi,
+                (SELECT MIN(post_id) FROM posts WHERE board_id = #{boardId} AND post_id &gt; #{postId} AND state != 'deleted') AS nextPostApi
             </otherwise>
         </choose>
         FROM posts p
@@ -100,6 +103,7 @@
         LEFT JOIN categories ct ON p.category_id = ct.category_id
         WHERE p.post_id = #{postId}
         AND p.board_id = #{boardId}
+        AND p.state != 'deleted'
     </select>
 
     <select id="findAttachmentsByPostId" resultType="com.back.student.free.dto.AttachmentFileResponse">
@@ -123,6 +127,7 @@
         FROM comments c
                  JOIN users u ON c.user_id = u.user_id
         WHERE c.post_id = #{postId}
+          AND c.state != 'deleted'
         ORDER BY c.created_at ASC
     </select>
 
@@ -184,6 +189,10 @@
         WHERE post_id = #{postId}
     </delete>
 
+    <update id="softDeletePost">
+        UPDATE posts SET state = 'deleted' WHERE post_id = #{postId}
+    </update>
+
     <insert id="insertComment">
         INSERT INTO comments (post_id, user_id, content, is_anonymous, created_at)
         VALUES (#{postId}, #{userId}, #{request.content}, #{request.isAnonymous},  NOW())
@@ -204,5 +213,9 @@
     <delete id="deleteComment">
         DELETE FROM comments WHERE comment_id = #{commentId}
     </delete>
+
+    <update id="softDeleteComment">
+        UPDATE comments SET state = 'deleted' WHERE comment_id = #{commentId}
+    </update>
 
 </mapper>

--- a/src/main/resources/mapper/student/InfoMapper.xml
+++ b/src/main/resources/mapper/student/InfoMapper.xml
@@ -15,6 +15,7 @@
                title
         FROM posts
         WHERE board_id = #{boardId}
+          AND state != 'deleted'
         ORDER BY created_at DESC
             LIMIT 5
     </select>
@@ -34,6 +35,7 @@
         INNER JOIN users u ON p.user_id = u.user_id
         LEFT JOIN categories c ON p.category_id = c.category_id
         WHERE p.board_id = #{boardId}
+          AND p.state != 'deleted'
         <if test="categoryId != null">
             AND p.category_id = #{categoryId}
         </if>
@@ -52,6 +54,7 @@
         SELECT COUNT(*)
         FROM posts
         WHERE board_id = #{boardId}
+          AND state != 'deleted'
         <if test="categoryId != null">
             AND category_id = #{categoryId}
         </if>
@@ -79,17 +82,17 @@
         <choose>
             <when test="sort == 'viewCount'">
                 (SELECT post_id FROM posts
-                WHERE board_id = #{boardId} AND post_id != p.post_id
+                WHERE board_id = #{boardId} AND post_id != p.post_id AND state != 'deleted'
                 AND (view_count &gt; p.view_count OR (view_count = p.view_count AND post_id &gt; p.post_id))
                 ORDER BY view_count ASC, post_id ASC LIMIT 1) AS prevPostApi,
                 (SELECT post_id FROM posts
-                WHERE board_id = #{boardId} AND post_id != p.post_id
+                WHERE board_id = #{boardId} AND post_id != p.post_id AND state != 'deleted'
                 AND (view_count &lt; p.view_count OR (view_count = p.view_count AND post_id &lt; p.post_id))
                 ORDER BY view_count DESC, post_id DESC LIMIT 1) AS nextPostApi
             </when>
             <otherwise>
-                (SELECT MAX(post_id) FROM posts WHERE board_id = #{boardId} AND post_id &lt; #{postId}) AS prevPostApi,
-                (SELECT MIN(post_id) FROM posts WHERE board_id = #{boardId} AND post_id &gt; #{postId}) AS nextPostApi
+                (SELECT MAX(post_id) FROM posts WHERE board_id = #{boardId} AND post_id &lt; #{postId} AND state != 'deleted') AS prevPostApi,
+                (SELECT MIN(post_id) FROM posts WHERE board_id = #{boardId} AND post_id &gt; #{postId} AND state != 'deleted') AS nextPostApi
             </otherwise>
         </choose>
         FROM posts p
@@ -97,6 +100,7 @@
         LEFT JOIN categories ct ON p.category_id = ct.category_id
         WHERE p.post_id = #{postId}
         AND p.board_id = #{boardId}
+        AND p.state != 'deleted'
     </select>
 
     <select id="findAttachmentsByPostId" resultType="com.back.student.info.dto.AttachmentFileResponse">
@@ -119,6 +123,7 @@
         FROM comments c
                  JOIN users u ON c.user_id = u.user_id
         WHERE c.post_id = #{postId}
+          AND c.state != 'deleted'
         ORDER BY c.created_at ASC
     </select>
 
@@ -179,6 +184,10 @@
         WHERE post_id = #{postId}
     </delete>
 
+    <update id="softDeletePost">
+        UPDATE posts SET state = 'deleted' WHERE post_id = #{postId}
+    </update>
+
     <insert id="insertComment">
         INSERT INTO comments (post_id, user_id, content, is_private, created_at)
         VALUES (#{postId}, #{userId}, #{request.content}, #{request.isPrivate}, NOW())
@@ -199,5 +208,9 @@
     <delete id="deleteComment">
         DELETE FROM comments WHERE comment_id = #{commentId}
     </delete>
+
+    <update id="softDeleteComment">
+        UPDATE comments SET state = 'deleted' WHERE comment_id = #{commentId}
+    </update>
 
 </mapper>

--- a/src/main/resources/sql/reports_log_schema_update.sql
+++ b/src/main/resources/sql/reports_log_schema_update.sql
@@ -1,0 +1,10 @@
+-- reports_log 처리 시각 / 처리 결과 연결 컬럼 추가
+-- Flyway/Liquibase 미사용 프로젝트라 자동 실행되지 않음. 직접 DB에 실행할 것.
+
+ALTER TABLE reports_log
+    ADD COLUMN resolved_at DATETIME NULL COMMENT '처리(수락/거절) 시각',
+    ADD COLUMN resolution_action_id BIGINT NULL COMMENT '수락(삭제 처리)된 경우 연결되는 moderation_log 액션';
+
+ALTER TABLE reports_log
+    ADD CONSTRAINT fk_reports_resolution
+        FOREIGN KEY (resolution_action_id) REFERENCES moderation_log (action_id) ON UPDATE CASCADE;

--- a/src/main/resources/sql/sanction_seed.sql
+++ b/src/main/resources/sql/sanction_seed.sql
@@ -1,0 +1,21 @@
+-- 유저 정지/영구차단 + 주의·경고 패널티 시스템 초기 시드 데이터
+-- Flyway/Liquibase 미사용 프로젝트라 자동 실행되지 않음. 직접 DB에 실행할 것.
+-- qa_pilsa DB에는 이미 아래와 동일한 값으로 세팅되어 있음이 확인됨(2026-08-11) - 새 환경/로컬 DB용 참고 스크립트.
+-- 주의: policy_settings.code는 'caution_per_warning'이 아니라 'cautions_per_warning'(복수형)이 실제 사용 중인 이름임.
+
+INSERT INTO ban_policy (code, warning_no, ban_type, ban_days, description) VALUES
+ ('BAN_W1', 1, 'temporary', 7,    '경고 1점: 1주일 정지'),
+ ('BAN_W2', 2, 'temporary', 30,   '경고 2점: 한달 정지'),
+ ('BAN_W3', 3, 'permanent', NULL, '경고 3점: 영구 차단')
+ON DUPLICATE KEY UPDATE
+    ban_type = VALUES(ban_type),
+    ban_days = VALUES(ban_days),
+    description = VALUES(description);
+
+INSERT INTO policy_settings (code, setting_value, description) VALUES
+ ('caution_per_delete',    '2',   '게시글/댓글 삭제 시 부여되는 주의 포인트'),
+ ('cautions_per_warning',  '10',  '경고 1점으로 전환되는 주의 포인트 총합'),
+ ('caution_ttl_days',      '365', '주의 포인트 유효기간(일)'),
+ ('warning_ttl_days',      '365', '경고 유효기간(일)')
+ON DUPLICATE KEY UPDATE
+    setting_value = VALUES(setting_value);

--- a/src/main/resources/sql/sanction_test_scenarios.sql
+++ b/src/main/resources/sql/sanction_test_scenarios.sql
@@ -1,0 +1,210 @@
+-- ============================================================
+-- 제재회원관리 화면 테스트용 시나리오 픽스처
+-- 실행 전제: sanction_seed.sql, reports_log_schema_update.sql 를 먼저 실행할 것
+-- 실행 방법: 전체를 한 세션(스크립트 실행)으로 실행해야 함 (LAST_INSERT_ID() 세션변수 사용)
+-- 테스트 계정 공용 비밀번호: Test1234!  (BCrypt: $2a$10$aVbi97czhxp8gtp6Buzi8eXSuwIVmIxFB24Du.cfYygGalJiD6Etm)
+-- 정리(삭제)하려면 파일 맨 아래 CLEANUP 섹션 참고
+-- ============================================================
+
+SET @PW_HASH = '$2a$10$aVbi97czhxp8gtp6Buzi8eXSuwIVmIxFB24Du.cfYygGalJiD6Etm';
+SET @FREE_BOARD_ID = 2;
+
+-- ============================================================
+-- 1) test_caution : 주의 태그(캐션 8점, 아직 정지/차단 아님)
+--    -> Swagger에서 아래 '라이브 삭제 테스트용 게시글'을 관리자 강제삭제 API로 삭제하면
+--       8+2=10점이 되어 그 순간 경고 1회 + 1주 정지로 전환되는 걸 실시간으로 확인 가능
+-- ============================================================
+INSERT INTO users (name, phone, major, student_no, email, login_id, password_hash, role, is_deleted)
+VALUES ('테스트_주의', '010-9999-0001', 'TEST', '90000001', 'test_caution@qa.pilsa.test', 'test_caution', @PW_HASH, 'STUDENTS', 0);
+SET @caution_user_id = LAST_INSERT_ID();
+
+INSERT INTO posts (title, content, user_id, board_id, is_anonymous, created_at, state)
+VALUES ('[TEST] 주의 히스토리용 게시글', '시드 데이터 - 이미 처리된 것으로 간주', @caution_user_id, @FREE_BOARD_ID, 0, NOW(), 'deleted');
+SET @caution_post_hist = LAST_INSERT_ID();
+
+INSERT INTO moderation_log (target_type, target_id, applied_state, reason_id, detail, acted_by, created_at)
+VALUES ('post', @caution_post_hist, 'deleted', (SELECT reason_id FROM reasons ORDER BY reason_id LIMIT 1), '[TEST] 시드 데이터', NULL, NOW());
+SET @caution_action_id = LAST_INSERT_ID();
+
+INSERT INTO penalty_log (user_id, points, target_type, target_id, source_action_id, created_at, expires_at)
+VALUES (@caution_user_id, 8, 'post', @caution_post_hist, @caution_action_id, NOW(), DATE_ADD(NOW(), INTERVAL 90 DAY));
+
+INSERT INTO posts (title, content, user_id, board_id, is_anonymous, created_at, state)
+VALUES ('[TEST] 라이브 삭제 테스트용 게시글', 'Swagger에서 관리자 강제삭제 API로 이 글을 삭제해보세요', @caution_user_id, @FREE_BOARD_ID, 0, NOW(), 'normal');
+SET @caution_post_live = LAST_INSERT_ID();
+
+-- ============================================================
+-- 2) test_susp1w : 경고 1회 -> 1주 정지 중
+-- ============================================================
+INSERT INTO users (name, phone, major, student_no, email, login_id, password_hash, role, is_deleted)
+VALUES ('테스트_정지1주', '010-9999-0002', 'TEST', '90000002', 'test_susp1w@qa.pilsa.test', 'test_susp1w', @PW_HASH, 'STUDENTS', 0);
+SET @susp1w_id = LAST_INSERT_ID();
+
+INSERT INTO posts (title, content, user_id, board_id, is_anonymous, created_at, state)
+VALUES ('[TEST] 정지1주 히스토리용 게시글', '시드 데이터', @susp1w_id, @FREE_BOARD_ID, 0, NOW(), 'deleted');
+SET @susp1w_post = LAST_INSERT_ID();
+
+INSERT INTO moderation_log (target_type, target_id, applied_state, reason_id, detail, acted_by, created_at)
+VALUES ('post', @susp1w_post, 'deleted', (SELECT reason_id FROM reasons ORDER BY reason_id LIMIT 1), '[TEST] 시드 데이터', NULL, DATE_SUB(NOW(), INTERVAL 1 DAY));
+SET @susp1w_action = LAST_INSERT_ID();
+
+INSERT INTO penalty_log (user_id, points, target_type, target_id, source_action_id, created_at, expires_at)
+VALUES (@susp1w_id, 10, 'post', @susp1w_post, @susp1w_action, DATE_SUB(NOW(), INTERVAL 1 DAY), DATE_ADD(NOW(), INTERVAL 89 DAY));
+
+INSERT INTO warning_log (user_id, created_at, expires_at)
+VALUES (@susp1w_id, DATE_SUB(NOW(), INTERVAL 1 DAY), DATE_ADD(NOW(), INTERVAL 364 DAY));
+
+INSERT INTO ban_log (user_id, warning_no, ban_type, starts_at, ends_at, created_at)
+VALUES (@susp1w_id, 1, 'temporary', DATE_SUB(NOW(), INTERVAL 1 DAY), DATE_ADD(NOW(), INTERVAL 6 DAY), DATE_SUB(NOW(), INTERVAL 1 DAY));
+
+UPDATE users SET ban_status = 'temporary', banned_until = DATE_ADD(NOW(), INTERVAL 6 DAY) WHERE user_id = @susp1w_id;
+
+-- ============================================================
+-- 3) test_susp1m : 경고 2회 -> 1개월 정지 중
+-- ============================================================
+INSERT INTO users (name, phone, major, student_no, email, login_id, password_hash, role, is_deleted)
+VALUES ('테스트_정지1개월', '010-9999-0003', 'TEST', '90000003', 'test_susp1m@qa.pilsa.test', 'test_susp1m', @PW_HASH, 'STUDENTS', 0);
+SET @susp1m_id = LAST_INSERT_ID();
+
+INSERT INTO posts (title, content, user_id, board_id, is_anonymous, created_at, state)
+VALUES ('[TEST] 정지1개월 히스토리용 게시글', '시드 데이터', @susp1m_id, @FREE_BOARD_ID, 0, NOW(), 'deleted');
+SET @susp1m_post = LAST_INSERT_ID();
+
+INSERT INTO moderation_log (target_type, target_id, applied_state, reason_id, detail, acted_by, created_at)
+VALUES ('post', @susp1m_post, 'deleted', (SELECT reason_id FROM reasons ORDER BY reason_id LIMIT 1), '[TEST] 시드 데이터', NULL, DATE_SUB(NOW(), INTERVAL 2 DAY));
+SET @susp1m_action = LAST_INSERT_ID();
+
+INSERT INTO penalty_log (user_id, points, target_type, target_id, source_action_id, created_at, expires_at)
+VALUES (@susp1m_id, 20, 'post', @susp1m_post, @susp1m_action, DATE_SUB(NOW(), INTERVAL 2 DAY), DATE_ADD(NOW(), INTERVAL 88 DAY));
+
+INSERT INTO warning_log (user_id, created_at, expires_at) VALUES
+    (@susp1m_id, DATE_SUB(NOW(), INTERVAL 2 DAY), DATE_ADD(NOW(), INTERVAL 363 DAY)),
+    (@susp1m_id, DATE_SUB(NOW(), INTERVAL 2 DAY), DATE_ADD(NOW(), INTERVAL 363 DAY));
+
+INSERT INTO ban_log (user_id, warning_no, ban_type, starts_at, ends_at, created_at)
+VALUES (@susp1m_id, 2, 'temporary', DATE_SUB(NOW(), INTERVAL 2 DAY), DATE_ADD(NOW(), INTERVAL 28 DAY), DATE_SUB(NOW(), INTERVAL 2 DAY));
+
+UPDATE users SET ban_status = 'temporary', banned_until = DATE_ADD(NOW(), INTERVAL 28 DAY) WHERE user_id = @susp1m_id;
+
+-- ============================================================
+-- 4) test_banned : 경고 3회 -> 영구차단
+-- ============================================================
+INSERT INTO users (name, phone, major, student_no, email, login_id, password_hash, role, is_deleted)
+VALUES ('테스트_영구차단', '010-9999-0004', 'TEST', '90000004', 'test_banned@qa.pilsa.test', 'test_banned', @PW_HASH, 'STUDENTS', 0);
+SET @banned_id = LAST_INSERT_ID();
+
+INSERT INTO posts (title, content, user_id, board_id, is_anonymous, created_at, state)
+VALUES ('[TEST] 영구차단 히스토리용 게시글', '시드 데이터', @banned_id, @FREE_BOARD_ID, 0, NOW(), 'deleted');
+SET @banned_post = LAST_INSERT_ID();
+
+INSERT INTO moderation_log (target_type, target_id, applied_state, reason_id, detail, acted_by, created_at)
+VALUES ('post', @banned_post, 'deleted', (SELECT reason_id FROM reasons ORDER BY reason_id LIMIT 1), '[TEST] 시드 데이터', NULL, DATE_SUB(NOW(), INTERVAL 3 DAY));
+SET @banned_action = LAST_INSERT_ID();
+
+INSERT INTO penalty_log (user_id, points, target_type, target_id, source_action_id, created_at, expires_at)
+VALUES (@banned_id, 30, 'post', @banned_post, @banned_action, DATE_SUB(NOW(), INTERVAL 3 DAY), DATE_ADD(NOW(), INTERVAL 87 DAY));
+
+INSERT INTO warning_log (user_id, created_at, expires_at) VALUES
+    (@banned_id, DATE_SUB(NOW(), INTERVAL 3 DAY), DATE_ADD(NOW(), INTERVAL 362 DAY)),
+    (@banned_id, DATE_SUB(NOW(), INTERVAL 3 DAY), DATE_ADD(NOW(), INTERVAL 362 DAY)),
+    (@banned_id, DATE_SUB(NOW(), INTERVAL 3 DAY), DATE_ADD(NOW(), INTERVAL 362 DAY));
+
+INSERT INTO ban_log (user_id, warning_no, ban_type, starts_at, ends_at, created_at)
+VALUES (@banned_id, 3, 'permanent', DATE_SUB(NOW(), INTERVAL 3 DAY), NULL, DATE_SUB(NOW(), INTERVAL 3 DAY));
+
+UPDATE users SET ban_status = 'permanent', banned_until = NULL WHERE user_id = @banned_id;
+
+-- ============================================================
+-- 5) test_expired : 정지 기간은 이미 지났지만 ban_status 캐시가 아직 안 정리된 상태
+--    -> 로그인은 즉시 성공해야 함 (실시간 판정), 목록엔 스케줄러 돌기 전까지 계속 '정지'로 남아있어야 함
+-- ============================================================
+INSERT INTO users (name, phone, major, student_no, email, login_id, password_hash, role, is_deleted)
+VALUES ('테스트_만료됨', '010-9999-0005', 'TEST', '90000005', 'test_expired@qa.pilsa.test', 'test_expired', @PW_HASH, 'STUDENTS', 0);
+SET @expired_id = LAST_INSERT_ID();
+
+INSERT INTO posts (title, content, user_id, board_id, is_anonymous, created_at, state)
+VALUES ('[TEST] 정지만료 히스토리용 게시글', '시드 데이터', @expired_id, @FREE_BOARD_ID, 0, NOW(), 'deleted');
+SET @expired_post = LAST_INSERT_ID();
+
+INSERT INTO moderation_log (target_type, target_id, applied_state, reason_id, detail, acted_by, created_at)
+VALUES ('post', @expired_post, 'deleted', (SELECT reason_id FROM reasons ORDER BY reason_id LIMIT 1), '[TEST] 시드 데이터', NULL, DATE_SUB(NOW(), INTERVAL 8 DAY));
+SET @expired_action = LAST_INSERT_ID();
+
+INSERT INTO penalty_log (user_id, points, target_type, target_id, source_action_id, created_at, expires_at)
+VALUES (@expired_id, 10, 'post', @expired_post, @expired_action, DATE_SUB(NOW(), INTERVAL 8 DAY), DATE_ADD(NOW(), INTERVAL 82 DAY));
+
+INSERT INTO warning_log (user_id, created_at, expires_at)
+VALUES (@expired_id, DATE_SUB(NOW(), INTERVAL 8 DAY), DATE_ADD(NOW(), INTERVAL 357 DAY));
+
+INSERT INTO ban_log (user_id, warning_no, ban_type, starts_at, ends_at, created_at)
+VALUES (@expired_id, 1, 'temporary', DATE_SUB(NOW(), INTERVAL 8 DAY), DATE_SUB(NOW(), INTERVAL 1 DAY), DATE_SUB(NOW(), INTERVAL 8 DAY));
+
+-- 스케줄러가 아직 안 돈 것처럼 일부러 캐시를 그대로(temporary) 남겨둠
+UPDATE users SET ban_status = 'temporary', banned_until = DATE_SUB(NOW(), INTERVAL 1 DAY) WHERE user_id = @expired_id;
+
+-- ============================================================
+-- 6) 신고 시나리오: test_reported_author(피신고자) / test_reporter(신고자)
+-- ============================================================
+INSERT INTO users (name, phone, major, student_no, email, login_id, password_hash, role, is_deleted)
+VALUES ('테스트_피신고자', '010-9999-0006', 'TEST', '90000006', 'test_reported@qa.pilsa.test', 'test_reported_author', @PW_HASH, 'STUDENTS', 0);
+SET @reported_id = LAST_INSERT_ID();
+
+INSERT INTO users (name, phone, major, student_no, email, login_id, password_hash, role, is_deleted)
+VALUES ('테스트_신고자', '010-9999-0007', 'TEST', '90000007', 'test_reporter@qa.pilsa.test', 'test_reporter', @PW_HASH, 'STUDENTS', 0);
+SET @reporter_id = LAST_INSERT_ID();
+
+-- 6-1) 아직 처리 안 된(pending) 신고 대상 게시글 + 댓글 -> Swagger로 수락/거절 라이브 테스트용
+INSERT INTO posts (title, content, user_id, board_id, is_anonymous, created_at, state)
+VALUES ('[TEST] 신고 대기중인 게시글', 'Swagger에서 신고 수락/거절 API로 처리해보세요', @reported_id, @FREE_BOARD_ID, 0, NOW(), 'normal');
+SET @rep_post_pending = LAST_INSERT_ID();
+
+INSERT INTO comments (post_id, user_id, content, is_anonymous, created_at, state)
+VALUES (@rep_post_pending, @reported_id, '[TEST] 신고 대기중인 댓글', 0, NOW(), 'normal');
+SET @rep_comment_pending = LAST_INSERT_ID();
+
+INSERT INTO reports_log (reporter_id, target_type, target_id, reason_id, detail, status, created_at)
+VALUES (@reporter_id, 'post', @rep_post_pending, (SELECT reason_id FROM reasons ORDER BY reason_id LIMIT 1), NULL, 'pending', NOW());
+
+INSERT INTO reports_log (reporter_id, target_type, target_id, reason_id, detail, status, created_at)
+VALUES (@reporter_id, 'comment', @rep_comment_pending,
+        COALESCE((SELECT reason_id FROM reasons ORDER BY reason_id LIMIT 1 OFFSET 1),
+                 (SELECT reason_id FROM reasons ORDER BY reason_id LIMIT 1)),
+        NULL, 'pending', NOW());
+
+-- 6-2) 이미 수락(삭제 처리)된 신고 히스토리
+INSERT INTO posts (title, content, user_id, board_id, is_anonymous, created_at, state)
+VALUES ('[TEST] 이미 삭제 처리된 게시글', '시드 데이터', @reported_id, @FREE_BOARD_ID, 0, DATE_SUB(NOW(), INTERVAL 2 DAY), 'deleted');
+SET @rep_post_resolved = LAST_INSERT_ID();
+
+INSERT INTO moderation_log (target_type, target_id, applied_state, reason_id, detail, acted_by, created_at)
+VALUES ('post', @rep_post_resolved, 'deleted', (SELECT reason_id FROM reasons ORDER BY reason_id LIMIT 1), '[TEST] 시드 데이터', NULL, DATE_SUB(NOW(), INTERVAL 1 DAY));
+SET @rep_action_resolved = LAST_INSERT_ID();
+
+INSERT INTO penalty_log (user_id, points, target_type, target_id, source_action_id, created_at, expires_at)
+VALUES (@reported_id, 2, 'post', @rep_post_resolved, @rep_action_resolved, DATE_SUB(NOW(), INTERVAL 1 DAY), DATE_ADD(NOW(), INTERVAL 89 DAY));
+
+INSERT INTO reports_log (reporter_id, target_type, target_id, reason_id, detail, status, created_at, resolved_at, resolution_action_id)
+VALUES (@reporter_id, 'post', @rep_post_resolved, (SELECT reason_id FROM reasons ORDER BY reason_id LIMIT 1), NULL, 'resolved', DATE_SUB(NOW(), INTERVAL 2 DAY), DATE_SUB(NOW(), INTERVAL 1 DAY), @rep_action_resolved);
+
+-- 6-3) 거절된 신고 히스토리
+INSERT INTO posts (title, content, user_id, board_id, is_anonymous, created_at, state)
+VALUES ('[TEST] 신고가 거절된 게시글', '시드 데이터', @reported_id, @FREE_BOARD_ID, 0, DATE_SUB(NOW(), INTERVAL 3 DAY), 'normal');
+SET @rep_post_rejected = LAST_INSERT_ID();
+
+INSERT INTO reports_log (reporter_id, target_type, target_id, reason_id, detail, status, created_at, resolved_at, resolution_action_id)
+VALUES (@reporter_id, 'post', @rep_post_rejected,
+        COALESCE((SELECT reason_id FROM reasons ORDER BY reason_id LIMIT 1 OFFSET 2),
+                 (SELECT reason_id FROM reasons ORDER BY reason_id LIMIT 1)),
+        '[TEST] 근거 부족으로 거절', 'rejected', DATE_SUB(NOW(), INTERVAL 3 DAY), DATE_SUB(NOW(), INTERVAL 2 DAY), NULL);
+
+-- ============================================================
+-- CLEANUP (테스트 끝나고 지울 때 이 아래를 별도로 실행)
+-- ============================================================
+-- DELETE FROM reports_log WHERE reporter_id IN (SELECT user_id FROM users WHERE login_id LIKE 'test_%');
+-- DELETE FROM ban_log WHERE user_id IN (SELECT user_id FROM users WHERE login_id LIKE 'test_%');
+-- DELETE FROM warning_log WHERE user_id IN (SELECT user_id FROM users WHERE login_id LIKE 'test_%');
+-- DELETE FROM penalty_log WHERE user_id IN (SELECT user_id FROM users WHERE login_id LIKE 'test_%');
+-- DELETE FROM moderation_log WHERE acted_by IS NULL AND detail = '[TEST] 시드 데이터';
+-- DELETE FROM comments WHERE user_id IN (SELECT user_id FROM users WHERE login_id LIKE 'test_%');
+-- DELETE FROM posts WHERE user_id IN (SELECT user_id FROM users WHERE login_id LIKE 'test_%');
+-- DELETE FROM users WHERE login_id LIKE 'test_%';


### PR DESCRIPTION
## Summary
- 게시글/댓글 삭제 시 주의(+2점) -> 경고(10점당 1회) -> 정지(1주/1개월)/영구차단이 자동으로 적용되도록 ban_policy/penalty_log/warning_log/ban_log 기반 패널티 시스템 구현
- 로그인 및 매 요청(JWT 필터)에서 실시간으로 정지/차단 여부를 체크, 만료된 임시정지는 매시간 스케줄러로 users.ban_status 캐시 정리
- free/info 게시판에 관리자 강제 삭제(소프트 삭제, state='deleted') API 추가, 목록/상세 조회에서 삭제된 글 제외
- 신고 접수(/api/stu/reports) / 수락(삭제 처리) / 거절 API 및 제재회원 관리 화면용 목록·상세조회 API(/api/admin/sanctions/**, /api/admin/reports/**) 추가
- DB에 이미 있던 policy_settings 키(cautions_per_warning)와 코드에서 조회하던 키(caution_per_warning)가 달랐던 버그 수정

## DB 변경사항 (직접 실행 필요, Flyway 미사용)
- src/main/resources/sql/reports_log_schema_update.sql - reports_log에 resolved_at, resolution_action_id(FK) 컬럼 추가 — qa_pilsa DB엔 이미 적용함
- src/main/resources/sql/sanction_seed.sql - qa_pilsa DB엔 이미 동일한 값으로 존재, 새 환경용 참고 스크립트
- src/main/resources/sql/sanction_test_scenarios.sql - 리뷰용 테스트 시나리오 픽스처, qa_pilsa DB에 시드 완료

## Test plan
- [x] ./gradlew.bat test (컨텍스트 로딩 + 전체 매퍼 XML 파싱 통과)
- [x] qa_pilsa DB에 스키마 변경 및 테스트 픽스처 직접 적용, 데이터 정합성 확인
- [ ] Swagger로 관리자 강제삭제/신고 수락·거절 API 라이브 테스트

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>