### PR TITLE
ci: self-hosted runner 기반 QA/운영 자동 배포

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,37 +1,31 @@
 name: Deploy Production
 
-# 수동 트리거 전용: Actions 탭 → Deploy Production → Run workflow
-# release 브랜치를 운영(포트 8080, pilsa.service)에 배포
+# release 브랜치 push 시 운영(포트 8080, pilsa.service)에 자동 배포
 on:
+  push:
+    branches: [release]
   workflow_dispatch:
 
 concurrency:
   group: deploy-backend-prod
   cancel-in-progress: false
 
+env:
+  DEPLOY_BRANCH: release
+
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 25
     steps:
-      - name: Configure SSH
-        run: |
-          mkdir -p ~/.ssh
-          echo "${{ secrets.PILSA_SSH_KEY }}" > ~/.ssh/deploy_key
-          chmod 600 ~/.ssh/deploy_key
-          ssh-keyscan -H "${{ secrets.PILSA_HOST }}" >> ~/.ssh/known_hosts 2>/dev/null
-
       - name: Deploy backend to Production
         run: |
-          ssh -i ~/.ssh/deploy_key \
-              -o ServerAliveInterval=30 -o ServerAliveCountMax=40 \
-              "${{ secrets.PILSA_USER }}@${{ secrets.PILSA_HOST }}" 'bash -s' <<'DEPLOY'
           set -euo pipefail
 
-          echo "===== [1/4] 소스 최신화 (origin/release) ====="
+          echo "===== [1/4] 소스 최신화 (origin/${DEPLOY_BRANCH}) ====="
           cd ~/backend
-          git fetch origin release
-          git reset --hard origin/release
+          git fetch origin "${DEPLOY_BRANCH}"
+          git reset --hard "origin/${DEPLOY_BRANCH}"
           git log --oneline -1
 
           echo "===== [2/4] Gradle 빌드 ====="
@@ -54,4 +48,3 @@ jobs:
           echo "운영 백엔드가 기동하지 않았습니다. 최근 로그:"
           sudo journalctl -u pilsa -n 50 --no-pager
           exit 1
-          DEPLOY

--- a/.github/workflows/deploy-qa.yml
+++ b/.github/workflows/deploy-qa.yml
@@ -1,6 +1,6 @@
 name: Deploy QA
 
-# dev 브랜치에 push 되면 QA(포트 8081, pilsa-qa.service)에 자동 배포
+# dev 브랜치 push 시 QA(포트 8081, pilsa-qa.service)에 자동 배포
 on:
   push:
     branches: [dev]
@@ -10,29 +10,22 @@ concurrency:
   group: deploy-backend-qa
   cancel-in-progress: false
 
+env:
+  DEPLOY_BRANCH: dev
+
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 25
     steps:
-      - name: Configure SSH
-        run: |
-          mkdir -p ~/.ssh
-          echo "${{ secrets.PILSA_SSH_KEY }}" > ~/.ssh/deploy_key
-          chmod 600 ~/.ssh/deploy_key
-          ssh-keyscan -H "${{ secrets.PILSA_HOST }}" >> ~/.ssh/known_hosts 2>/dev/null
-
       - name: Deploy backend to QA
         run: |
-          ssh -i ~/.ssh/deploy_key \
-              -o ServerAliveInterval=30 -o ServerAliveCountMax=40 \
-              "${{ secrets.PILSA_USER }}@${{ secrets.PILSA_HOST }}" 'bash -s' <<'DEPLOY'
           set -euo pipefail
 
-          echo "===== [1/4] 소스 최신화 (origin/dev) ====="
+          echo "===== [1/4] 소스 최신화 (origin/${DEPLOY_BRANCH}) ====="
           cd ~/backend-qa
-          git fetch origin dev
-          git reset --hard origin/dev
+          git fetch origin "${DEPLOY_BRANCH}"
+          git reset --hard "origin/${DEPLOY_BRANCH}"
           git log --oneline -1
 
           echo "===== [2/4] Gradle 빌드 ====="
@@ -55,4 +48,3 @@ jobs:
           echo "QA 백엔드가 기동하지 않았습니다. 최근 로그:"
           sudo journalctl -u pilsa-qa -n 50 --no-pager
           exit 1
-          DEPLOY


### PR DESCRIPTION
## 요약
- dev push 시 QA(pilsa-qa.service, 8081) 자동 배포
- release push 시 운영(pilsa.service, 8080) 자동 배포 — 워크플로우 파일은 release 브랜치 쪽 PR로 별도 적용
- 기존 SSH 접속 방식(dev에 남아있던 초안)을 self-hosted runner 방식으로 교체 (보안그룹 오픈 불필요)

## 검증
- practice-dev/practice-release 브랜치에서 QA·운영 배포 전 과정 검증 완료 (빌드→재시작→헬스체크)
- QA application.properties에 dev 신기능이 요구하는 push.vapid.* 3종 추가 완료

## 주의
- dev의 웹푸시 기능이 release로 머지되는 시점에는 운영 application.properties에도 push.vapid.* 3종 추가 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)