### PR TITLE
ci: release push 시 운영 자동 배포 워크플로우

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,0 +1,50 @@
+name: Deploy Production
+
+# release 브랜치 push 시 운영(포트 8080, pilsa.service)에 자동 배포
+on:
+  push:
+    branches: [release]
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-backend-prod
+  cancel-in-progress: false
+
+env:
+  DEPLOY_BRANCH: release
+
+jobs:
+  deploy:
+    runs-on: self-hosted
+    timeout-minutes: 25
+    steps:
+      - name: Deploy backend to Production
+        run: |
+          set -euo pipefail
+
+          echo "===== [1/4] 소스 최신화 (origin/${DEPLOY_BRANCH}) ====="
+          cd ~/backend
+          git fetch origin "${DEPLOY_BRANCH}"
+          git reset --hard "origin/${DEPLOY_BRANCH}"
+          git log --oneline -1
+
+          echo "===== [2/4] Gradle 빌드 ====="
+          chmod +x ./gradlew
+          ./gradlew build -x test
+
+          echo "===== [3/4] pilsa 서비스 재시작 ====="
+          sudo systemctl restart pilsa
+
+          echo "===== [4/4] 헬스체크 (포트 8080) ====="
+          for i in $(seq 1 30); do
+            sleep 2
+            code=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:8080/actuator/health || true)
+            if [ "$code" != "000" ]; then
+              echo "운영 백엔드 응답 확인 (HTTP $code, 약 $((i*2))초 소요)"
+              sudo systemctl is-active pilsa
+              exit 0
+            fi
+          done
+          echo "운영 백엔드가 기동하지 않았습니다. 최근 로그:"
+          sudo journalctl -u pilsa -n 50 --no-pager
+          exit 1


### PR DESCRIPTION
## 요약
release 브랜치에 push(머지)되면 self-hosted runner가 운영(pilsa.service, 8080)에 자동 배포합니다.
push 트리거 워크플로우는 대상 브랜치에 파일이 존재해야 동작하므로 release에도 추가합니다.

## 검증
practice-release 브랜치로 운영 배포 전 과정(빌드→재시작→헬스체크) 검증 완료.

🤖 Generated with [Claude Code](https://claude.com/claude-code)