### PR TITLE
feat: 관리자 대시보드 + 마이페이지 프로필/활동요약 + 비밀번호 변경

### DIFF
--- a/docs/integration-20260814/CHECKLIST.md
+++ b/docs/integration-20260814/CHECKLIST.md
@@ -168,6 +168,16 @@ ALTER TABLE `api_endpoints`
 -- 비밀번호 해시는 wm5256 과 동일하게 복사 (동일 비밀번호로 로그인). 상황: 재학/졸업/관리자Lv1~3/정지중/영구차단/정지만료/탈퇴
 -- 상세는 docs/integration-20260814/TEST-PLAN.md §1
 
+-- [2026-08-22] 관리자 대시보드 "신규 가입자"/"신규 게시글" 집계 기간 (AdminDashboardMapper.xml 이 로드, 기본 1일=오늘)
+INSERT INTO `policy_settings` (code, setting_value, description) VALUES
+('dashboard_new_user_period_days', '1', '관리자 대시보드 신규 가입자 집계 기간(일)'),
+('dashboard_new_post_period_days', '1', '관리자 대시보드 신규 게시글 집계 기간(일)');
+
+-- [2026-08-22] 마이페이지 "이번 학기 활동 요약" 학기 기준월 (MyPageServiceImpl 이 로드, 기본 3월/9월 시작)
+INSERT INTO `policy_settings` (code, setting_value, description) VALUES
+('semester1_start_month', '3', '1학기 시작월 (마이페이지 이번 학기 활동 요약 기준)'),
+('semester2_start_month', '9', '2학기 시작월 (마이페이지 이번 학기 활동 요약 기준)');
+
 -- [2026-08-16] 알림 수신 기기 등록부 (웹 푸시 채널 — PM 지시로 2기 개발). 세션성 데이터라 물리삭제 예외
 CREATE TABLE `notification_devices` (
   `device_id`   bigint       NOT NULL AUTO_INCREMENT COMMENT '알림 수신 기기 고유 번호',

--- a/src/main/java/com/back/admin/dashboard/controller/AdminDashboardController.java
+++ b/src/main/java/com/back/admin/dashboard/controller/AdminDashboardController.java
@@ -1,0 +1,51 @@
+package com.back.admin.dashboard.controller;
+
+import com.back.admin.dashboard.dto.AdminDashboardResponse;
+import com.back.admin.dashboard.service.AdminDashboardService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "관리자-대시보드",
+        description = "관리자 홈 화면 — 활동 요약(신규 가입자/처리 대기 신고/신규 게시글/전체 회원 수) + 최근 신고·최근 가입 회원 목록. " +
+                "신규 가입자·신규 게시글의 집계 기간은 policy_settings 로 설정한다. " +
+                "일정 달력·월별 일정은 별도 엔드포인트 없이 회원 화면과 동일한 GET /api/event 를 그대로 사용한다.")
+public class AdminDashboardController {
+
+    private final AdminDashboardService adminDashboardService;
+
+    @Operation(summary = "관리자 대시보드 요약", description = """
+            관리자 홈 진입 시 호출한다.
+
+            ### 응답 예시
+            ```json
+            {
+              "newUserCount": 3,
+              "pendingReportCount": 2,
+              "newPostCount": 6,
+              "totalUserCount": 121,
+              "recentReports": [
+                { "targetType": "post", "boardName": "자유게시판", "title": "글 제목", "reportedAt": "2026-05-03T10:12:00" }
+              ],
+              "recentUsers": [
+                { "userId": 1, "loginId": "ch400", "name": "김본명", "memberType": "STUDENT", "createdAt": "2026-06-05T09:00:00" }
+              ]
+            }
+            ```
+            - newUserCount(신규 가입자) / newPostCount(신규 게시글): 집계 기간은 `policy_settings`
+              (`dashboard_new_user_period_days` / `dashboard_new_post_period_days`, 기본 1일=오늘)에서 로드한다.
+              newUserCount는 **영구차단·탈퇴 상태가 아닌 회원만** 센다.
+            - pendingReportCount: 상태가 `pending`인 신고 건수(게시글+댓글 통합).
+            - totalUserCount: **영구차단·탈퇴 상태가 아닌** 전체 회원 수.
+            - recentReports.title: 신고 대상 게시글의 제목(댓글 신고는 소속 게시글의 제목).
+            - 일정 달력·월별 일정은 기존 `GET /api/event?from=&to=` 를 그대로 사용한다(관리자도 로그인 회원이라 별도 엔드포인트 불필요).""")
+    @GetMapping("/api/admin/dashboard")
+    public ResponseEntity<AdminDashboardResponse> getDashboard() {
+        return ResponseEntity.ok(adminDashboardService.getDashboard());
+    }
+}

--- a/src/main/java/com/back/admin/dashboard/dto/AdminDashboardResponse.java
+++ b/src/main/java/com/back/admin/dashboard/dto/AdminDashboardResponse.java
@@ -1,0 +1,25 @@
+package com.back.admin.dashboard.dto;
+
+import java.util.List;
+import lombok.Getter;
+
+// 관리자 홈 대시보드 응답 (오늘의 활동 요약 + 최근 신고/최근 가입 회원)
+@Getter
+public class AdminDashboardResponse {
+    private final int newUserCount;            // 오늘 신규 가입자 수
+    private final int pendingReportCount;       // 처리 대기 신고 대상 수 (게시글+댓글, 대상 단위)
+    private final int newPostCount;             // 오늘 신규 작성 게시글 수
+    private final long totalUserCount;          // 전체 회원 수
+    private final List<RecentReportResponse> recentReports;
+    private final List<RecentUserResponse> recentUsers;
+
+    public AdminDashboardResponse(int newUserCount, int pendingReportCount, int newPostCount, long totalUserCount,
+                                   List<RecentReportResponse> recentReports, List<RecentUserResponse> recentUsers) {
+        this.newUserCount = newUserCount;
+        this.pendingReportCount = pendingReportCount;
+        this.newPostCount = newPostCount;
+        this.totalUserCount = totalUserCount;
+        this.recentReports = recentReports;
+        this.recentUsers = recentUsers;
+    }
+}

--- a/src/main/java/com/back/admin/dashboard/dto/RecentReportResponse.java
+++ b/src/main/java/com/back/admin/dashboard/dto/RecentReportResponse.java
@@ -1,0 +1,15 @@
+package com.back.admin.dashboard.dto;
+
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.Setter;
+
+// 대시보드 "최근 신고" 한 행 (게시글/댓글 신고 통합, 최신순)
+@Getter
+@Setter
+public class RecentReportResponse {
+    private String targetType;      // 'post' / 'comment'
+    private String boardName;       // boards.name (댓글은 소속 게시글의 게시판)
+    private String title;           // 대상 게시글 제목 (댓글 신고는 소속 게시글의 제목)
+    private LocalDateTime reportedAt;
+}

--- a/src/main/java/com/back/admin/dashboard/dto/RecentUserResponse.java
+++ b/src/main/java/com/back/admin/dashboard/dto/RecentUserResponse.java
@@ -1,0 +1,16 @@
+package com.back.admin.dashboard.dto;
+
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.Setter;
+
+// 대시보드 "최근 가입 회원" 한 행
+@Getter
+@Setter
+public class RecentUserResponse {
+    private Long userId;
+    private String loginId;         // ID (예: ch400)
+    private String name;
+    private String memberType;      // STUDENT / ALUMNI
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/back/admin/dashboard/mapper/AdminDashboardMapper.java
+++ b/src/main/java/com/back/admin/dashboard/mapper/AdminDashboardMapper.java
@@ -1,0 +1,30 @@
+package com.back.admin.dashboard.mapper;
+
+import com.back.admin.dashboard.dto.RecentReportResponse;
+import com.back.admin.dashboard.dto.RecentUserResponse;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+
+@Mapper
+public interface AdminDashboardMapper {
+
+    // 최근 N일(policy_settings.dashboard_new_user_period_days) 가입 + 영구차단/탈퇴 제외
+    int countNewUsers();
+
+    // 최근 N일(policy_settings.dashboard_new_post_period_days) 작성 게시글 (삭제 제외)
+    int countNewPosts();
+
+    // 처리 대기(status='pending') 신고 건수 (게시글+댓글 통합)
+    int countPendingReports();
+
+    // 전체 회원 수 (영구차단/탈퇴 제외)
+    long countTotalUsers();
+
+    // 최근 신고 N건 (게시글/댓글 통합, 최신순)
+    List<RecentReportResponse> findRecentReports(@Param("limit") int limit);
+
+    // 최근 가입 회원 N명
+    List<RecentUserResponse> findRecentUsers(@Param("limit") int limit);
+}

--- a/src/main/java/com/back/admin/dashboard/service/AdminDashboardService.java
+++ b/src/main/java/com/back/admin/dashboard/service/AdminDashboardService.java
@@ -1,0 +1,7 @@
+package com.back.admin.dashboard.service;
+
+import com.back.admin.dashboard.dto.AdminDashboardResponse;
+
+public interface AdminDashboardService {
+    AdminDashboardResponse getDashboard();
+}

--- a/src/main/java/com/back/admin/dashboard/service/AdminDashboardServiceImpl.java
+++ b/src/main/java/com/back/admin/dashboard/service/AdminDashboardServiceImpl.java
@@ -1,0 +1,37 @@
+package com.back.admin.dashboard.service;
+
+import com.back.admin.dashboard.dto.AdminDashboardResponse;
+import com.back.admin.dashboard.dto.RecentReportResponse;
+import com.back.admin.dashboard.dto.RecentUserResponse;
+import com.back.admin.dashboard.mapper.AdminDashboardMapper;
+import com.back.global.security.AuthUtils;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminDashboardServiceImpl implements AdminDashboardService {
+
+    private static final int RECENT_LIST_SIZE = 5;
+
+    private final AdminDashboardMapper adminDashboardMapper;
+
+    @Override
+    public AdminDashboardResponse getDashboard() {
+        AuthUtils.requireAdmin();
+
+        int newUserCount = adminDashboardMapper.countNewUsers();
+        int pendingReportCount = adminDashboardMapper.countPendingReports();
+        int newPostCount = adminDashboardMapper.countNewPosts();
+        long totalUserCount = adminDashboardMapper.countTotalUsers();
+        List<RecentReportResponse> recentReports = adminDashboardMapper.findRecentReports(RECENT_LIST_SIZE);
+        List<RecentUserResponse> recentUsers = adminDashboardMapper.findRecentUsers(RECENT_LIST_SIZE);
+
+        return new AdminDashboardResponse(newUserCount, pendingReportCount, newPostCount, totalUserCount,
+                recentReports, recentUsers);
+    }
+}

--- a/src/main/java/com/back/auth/controller/PasswordChangeController.java
+++ b/src/main/java/com/back/auth/controller/PasswordChangeController.java
@@ -1,0 +1,47 @@
+package com.back.auth.controller;
+
+import com.back.auth.dto.PasswordChangeRequest;
+import com.back.auth.service.AuthService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "마이페이지-비밀번호 변경", description = "로그인 상태에서 현재 비밀번호를 재확인하고 새 비밀번호로 변경한다. 비로그인 초기화(PUT /api/auth/password/reset)와는 별개 API다.")
+public class PasswordChangeController {
+
+    private final AuthService authService;
+
+    @Operation(summary = "비밀번호 변경 (마이페이지, 로그인 상태)",
+            description = """
+                    마이페이지의 비밀번호 변경 화면에서 호출한다. **로그인 상태에서 현재 비밀번호를 재확인**하므로
+                    토큰만 탈취해서는 비밀번호를 바꿀 수 없다.
+
+                    ### 요청 예시
+                    ```json
+                    { "currentPassword": "oldpw1234!", "newPassword": "newpw5678@", "newPasswordConfirm": "newpw5678@" }
+                    ```
+
+                    ### 응답 예시
+                    ```json
+                    {"message":"비밀번호가 변경되었습니다."}
+                    ```
+                    실패: 400 {"message":"현재 비밀번호가 일치하지 않습니다."}
+                    실패: 400 {"message":"새 비밀번호가 새 비밀번호 확인과 일치하지 않습니다."}
+                    실패: 400 {"message":"비밀번호는 문자, 숫자, 특수문자를 포함한 8~20자여야 합니다."} (policy_settings.signup_password_regex)
+                    실패: 400 {"message":"새 비밀번호가 현재 비밀번호와 같습니다."}
+                    실패: 401 (미인증)
+                    """)
+    @PatchMapping("/api/user/mypage/password/reset")
+    public ResponseEntity<Map<String, String>> changePassword(@RequestBody PasswordChangeRequest request) {
+        authService.changePassword(request);
+        return ResponseEntity.ok(Map.of("message", "비밀번호가 변경되었습니다."));
+    }
+}

--- a/src/main/java/com/back/auth/dto/PasswordChangeRequest.java
+++ b/src/main/java/com/back/auth/dto/PasswordChangeRequest.java
@@ -1,0 +1,13 @@
+package com.back.auth.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+// 마이페이지 비밀번호 변경 — 현재 비밀번호 재확인 필수 (비로그인 초기화 PasswordResetRequest 와 별개)
+@Getter
+@Setter
+public class PasswordChangeRequest {
+    private String currentPassword;
+    private String newPassword;
+    private String newPasswordConfirm;
+}

--- a/src/main/java/com/back/auth/service/AuthService.java
+++ b/src/main/java/com/back/auth/service/AuthService.java
@@ -3,6 +3,7 @@ package com.back.auth.service;
 import com.back.auth.dto.AuthResponse;
 import com.back.auth.dto.LoginRequest;
 //import com.back.auth.dto.SignupRequest;
+import com.back.auth.dto.PasswordChangeRequest;
 import com.back.auth.dto.PasswordResetRequest;
 import com.back.auth.dto.SignupRequest;
 import com.back.auth.dto.FindIdVerifyRequest;
@@ -28,6 +29,9 @@ public interface AuthService {
     long verifyLoginIdAndEmailAndSendCode(String loginId, String email);
     // 비밀번호 초기화
     void resetPassword(PasswordResetRequest request);
+
+    // 마이페이지 비밀번호 변경 — 로그인 상태에서 현재 비밀번호 재확인 후 변경 (비로그인 초기화와 별개)
+    void changePassword(PasswordChangeRequest request);
 
     // 이메일 찾기 - 학번/이름 일치 시 마스킹된 이메일 반환
     String findMaskedEmail(String studentNo, String name);

--- a/src/main/java/com/back/auth/service/AuthServicempl.java
+++ b/src/main/java/com/back/auth/service/AuthServicempl.java
@@ -7,6 +7,7 @@ import com.back.auth.dto.WithdrawnBanInfo;
 import com.back.auth.exception.AuthException;
 import com.back.auth.mapper.WithdrawMapper;
 import com.back.auth.exception.BannedException;
+import com.back.global.security.AuthUtils;
 import com.back.global.security.JwtUtil;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
@@ -400,6 +401,38 @@ public class AuthServicempl implements AuthService {
         String encodedNewPassword = passwordEncoder.encode(request.getNewPassword());
         authMapper.updatePassword(user.getLoginId(), encodedNewPassword);
         redisTemplate.delete(verifiedKey); // 1회용 소진
+    }
+
+    // 마이페이지 비밀번호 변경 — 로그인 상태에서 현재 비밀번호를 재확인하므로 토큰 탈취만으로는 변경 불가
+    @Override
+    @Transactional
+    public void changePassword(PasswordChangeRequest request) {
+        Long userId = AuthUtils.currentUserId();
+        WithdrawTarget me = withdrawMapper.findWithdrawTarget(userId);
+        if (me == null) {
+            throw new AuthException("사용자 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+        }
+
+        if (request.getCurrentPassword() == null
+                || !passwordEncoder.matches(request.getCurrentPassword(), me.getPasswordHash())) {
+            throw new AuthException("현재 비밀번호가 일치하지 않습니다.", HttpStatus.BAD_REQUEST);
+        }
+
+        String newPassword = request.getNewPassword();
+        if (newPassword == null || !newPassword.equals(request.getNewPasswordConfirm())) {
+            throw new AuthException("새 비밀번호가 새 비밀번호 확인과 일치하지 않습니다.", HttpStatus.BAD_REQUEST);
+        }
+
+        // 회원가입과 동일 규칙 재사용(policy_settings.signup_password_regex)
+        requireMatch(newPassword, "signup_password_regex",
+                "^(?=.*[A-Za-z])(?=.*[0-9])(?=.*[^A-Za-z0-9]).{8,20}$",
+                "비밀번호는 문자, 숫자, 특수문자를 포함한 8~20자여야 합니다.");
+
+        if (passwordEncoder.matches(newPassword, me.getPasswordHash())) {
+            throw new AuthException("새 비밀번호가 현재 비밀번호와 같습니다.", HttpStatus.BAD_REQUEST);
+        }
+
+        authMapper.updatePassword(me.getLoginId(), passwordEncoder.encode(newPassword));
     }
 
     // 이메일 찾기 - 학번+이름 일치 시 마스킹된 이메일 반환

--- a/src/main/java/com/back/mypage/profile/controller/MyPageProfileController.java
+++ b/src/main/java/com/back/mypage/profile/controller/MyPageProfileController.java
@@ -1,0 +1,44 @@
+package com.back.mypage.profile.controller;
+
+import com.back.mypage.profile.dto.MyPageSummaryResponse;
+import com.back.mypage.profile.service.MyPageService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "마이페이지-프로필",
+        description = "마이페이지 상단 화면 — 전체 기간 활동 수(작성글/작성한 댓글/좋아요 누른 글) + 이번 학기 활동 요약(작성한 글/작성한 댓글/받은 좋아요). " +
+                "학기 기준월은 policy_settings(semester1_start_month/semester2_start_month)로 설정한다.")
+public class MyPageProfileController {
+
+    private final MyPageService myPageService;
+
+    @Operation(summary = "마이페이지 프로필/활동 요약", description = """
+            마이페이지 진입 시 호출한다.
+
+            ### 응답 예시
+            ```json
+            {
+              "loginId": "pilsagraphy",
+              "name": "김본명",
+              "joinedAt": "2026-07-14T10:00:00",
+              "postCount": 24,
+              "commentCount": 87,
+              "likedCount": 16,
+              "semester": { "posts": 3, "comments": 10, "receivedLikes": 5 }
+            }
+            ```
+            - postCount/commentCount/likedCount: 전체 기간, 블라인드·삭제 글/댓글은 제외(state='normal').
+            - semester: 이번 학기(policy_settings semester1_start_month/semester2_start_month, 기본 3월/9월 시작) 기준
+              작성한 글·댓글 수와, 이번 학기에 쓴 글이 받은 좋아요 수.
+              좋아요 자체엔 시간 기록이 없어 "받은 좋아요"는 글 작성 시점을 기준으로 집계한다.""")
+    @GetMapping("/api/user/mypage")
+    public ResponseEntity<MyPageSummaryResponse> getSummary() {
+        return ResponseEntity.ok(myPageService.getSummary());
+    }
+}

--- a/src/main/java/com/back/mypage/profile/dto/MyPageBasicInfoRow.java
+++ b/src/main/java/com/back/mypage/profile/dto/MyPageBasicInfoRow.java
@@ -1,0 +1,14 @@
+package com.back.mypage.profile.dto;
+
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.Setter;
+
+// users 조회 결과 (마이페이지 상단 기본 정보)
+@Getter
+@Setter
+public class MyPageBasicInfoRow {
+    private String loginId;
+    private String name;
+    private LocalDateTime joinedAt;
+}

--- a/src/main/java/com/back/mypage/profile/dto/MyPageSummaryResponse.java
+++ b/src/main/java/com/back/mypage/profile/dto/MyPageSummaryResponse.java
@@ -1,0 +1,28 @@
+package com.back.mypage.profile.dto;
+
+import java.time.LocalDateTime;
+import lombok.Getter;
+
+// 마이페이지 상단 화면 (프로필 + 전체 기간 활동 수 + 이번 학기 활동 요약)
+@Getter
+public class MyPageSummaryResponse {
+    private final String loginId;
+    private final String name;
+    private final LocalDateTime joinedAt;
+    private final int postCount;         // 전체 기간 작성글 수
+    private final int commentCount;      // 전체 기간 작성한 댓글 수
+    private final int likedCount;        // 전체 기간 좋아요 누른 글 수
+    private final SemesterActivityResponse semester;
+
+    public MyPageSummaryResponse(String loginId, String name, LocalDateTime joinedAt,
+                                  int postCount, int commentCount, int likedCount,
+                                  SemesterActivityResponse semester) {
+        this.loginId = loginId;
+        this.name = name;
+        this.joinedAt = joinedAt;
+        this.postCount = postCount;
+        this.commentCount = commentCount;
+        this.likedCount = likedCount;
+        this.semester = semester;
+    }
+}

--- a/src/main/java/com/back/mypage/profile/dto/SemesterActivityResponse.java
+++ b/src/main/java/com/back/mypage/profile/dto/SemesterActivityResponse.java
@@ -1,0 +1,17 @@
+package com.back.mypage.profile.dto;
+
+import lombok.Getter;
+
+// 이번 학기 활동 요약 (작성한 글/댓글, 받은 좋아요) — 학기 경계는 policy_settings로 설정
+@Getter
+public class SemesterActivityResponse {
+    private final int posts;
+    private final int comments;
+    private final int receivedLikes;
+
+    public SemesterActivityResponse(int posts, int comments, int receivedLikes) {
+        this.posts = posts;
+        this.comments = comments;
+        this.receivedLikes = receivedLikes;
+    }
+}

--- a/src/main/java/com/back/mypage/profile/mapper/MyPageMapper.java
+++ b/src/main/java/com/back/mypage/profile/mapper/MyPageMapper.java
@@ -1,0 +1,38 @@
+package com.back.mypage.profile.mapper;
+
+import com.back.mypage.profile.dto.MyPageBasicInfoRow;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.time.LocalDateTime;
+
+@Mapper
+public interface MyPageMapper {
+
+    // 로그인아이디/이름/가입일
+    MyPageBasicInfoRow findBasicInfo(@Param("userId") Long userId);
+
+    // 전체 기간 작성글 수 (state='normal')
+    int countMyPosts(@Param("userId") Long userId);
+
+    // 전체 기간 작성한 댓글 수 (state='normal')
+    int countMyComments(@Param("userId") Long userId);
+
+    // 전체 기간 좋아요 누른 글 수 (대상 글이 state='normal'인 것만)
+    int countMyLikedPosts(@Param("userId") Long userId);
+
+    // 기간 내 작성글 수
+    int countMyPostsInPeriod(@Param("userId") Long userId,
+                              @Param("from") LocalDateTime from, @Param("to") LocalDateTime to);
+
+    // 기간 내 작성한 댓글 수
+    int countMyCommentsInPeriod(@Param("userId") Long userId,
+                                 @Param("from") LocalDateTime from, @Param("to") LocalDateTime to);
+
+    // 기간 내 작성한 글이 받은 좋아요 수 (좋아요 자체엔 시간 기록이 없어 글 작성 시점 기준)
+    int countMyReceivedLikesInPeriod(@Param("userId") Long userId,
+                                      @Param("from") LocalDateTime from, @Param("to") LocalDateTime to);
+
+    // 정책값 단건 조회 (semester1_start_month / semester2_start_month)
+    String findPolicySetting(@Param("code") String code);
+}

--- a/src/main/java/com/back/mypage/profile/service/MyPageService.java
+++ b/src/main/java/com/back/mypage/profile/service/MyPageService.java
@@ -1,0 +1,7 @@
+package com.back.mypage.profile.service;
+
+import com.back.mypage.profile.dto.MyPageSummaryResponse;
+
+public interface MyPageService {
+    MyPageSummaryResponse getSummary();
+}

--- a/src/main/java/com/back/mypage/profile/service/MyPageServiceImpl.java
+++ b/src/main/java/com/back/mypage/profile/service/MyPageServiceImpl.java
@@ -1,0 +1,84 @@
+package com.back.mypage.profile.service;
+
+import com.back.global.security.AuthUtils;
+import com.back.mypage.profile.dto.MyPageBasicInfoRow;
+import com.back.mypage.profile.dto.MyPageSummaryResponse;
+import com.back.mypage.profile.dto.SemesterActivityResponse;
+import com.back.mypage.profile.mapper.MyPageMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MyPageServiceImpl implements MyPageService {
+
+    // 학기 기준월이 policy_settings 에 없거나 잘못된 값일 때의 기본값 (1학기=3월, 2학기=9월 시작)
+    private static final int DEFAULT_SEMESTER1_START_MONTH = 3;
+    private static final int DEFAULT_SEMESTER2_START_MONTH = 9;
+
+    private final MyPageMapper myPageMapper;
+
+    @Override
+    public MyPageSummaryResponse getSummary() {
+        Long userId = AuthUtils.currentUserId();
+
+        MyPageBasicInfoRow basicInfo = myPageMapper.findBasicInfo(userId);
+
+        int postCount = myPageMapper.countMyPosts(userId);
+        int commentCount = myPageMapper.countMyComments(userId);
+        int likedCount = myPageMapper.countMyLikedPosts(userId);
+
+        LocalDateTime[] semesterRange = resolveCurrentSemesterRange();
+        LocalDateTime from = semesterRange[0];
+        LocalDateTime to = semesterRange[1];
+
+        SemesterActivityResponse semester = new SemesterActivityResponse(
+                myPageMapper.countMyPostsInPeriod(userId, from, to),
+                myPageMapper.countMyCommentsInPeriod(userId, from, to),
+                myPageMapper.countMyReceivedLikesInPeriod(userId, from, to)
+        );
+
+        return new MyPageSummaryResponse(basicInfo.getLoginId(), basicInfo.getName(), basicInfo.getJoinedAt(),
+                postCount, commentCount, likedCount, semester);
+    }
+
+    // 오늘 기준 현재 학기의 [시작, 끝) 구간. 2학기는 연말을 넘기므로(예: 9월~다음해 2월) 연도 보정이 필요하다
+    private LocalDateTime[] resolveCurrentSemesterRange() {
+        int semester1StartMonth = parseMonth(
+                myPageMapper.findPolicySetting("semester1_start_month"), DEFAULT_SEMESTER1_START_MONTH);
+        int semester2StartMonth = parseMonth(
+                myPageMapper.findPolicySetting("semester2_start_month"), DEFAULT_SEMESTER2_START_MONTH);
+
+        LocalDate today = LocalDate.now();
+        int year = today.getYear();
+        int month = today.getMonthValue();
+
+        LocalDate start;
+        LocalDate endExclusive;
+        if (month >= semester1StartMonth && month < semester2StartMonth) {
+            start = LocalDate.of(year, semester1StartMonth, 1);
+            endExclusive = LocalDate.of(year, semester2StartMonth, 1);
+        } else if (month >= semester2StartMonth) {
+            start = LocalDate.of(year, semester2StartMonth, 1);
+            endExclusive = LocalDate.of(year + 1, semester1StartMonth, 1);
+        } else {
+            start = LocalDate.of(year - 1, semester2StartMonth, 1);
+            endExclusive = LocalDate.of(year, semester1StartMonth, 1);
+        }
+        return new LocalDateTime[]{start.atStartOfDay(), endExclusive.atStartOfDay()};
+    }
+
+    private int parseMonth(String value, int defaultValue) {
+        try {
+            int month = Integer.parseInt(value);
+            return (month >= 1 && month <= 12) ? month : defaultValue;
+        } catch (Exception e) {
+            return defaultValue;
+        }
+    }
+}

--- a/src/main/resources/mapper/admin/dashboard/AdminDashboardMapper.xml
+++ b/src/main/resources/mapper/admin/dashboard/AdminDashboardMapper.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.back.admin.dashboard.mapper.AdminDashboardMapper">
+
+    <!-- 기간은 policy_settings 에서 로드, 없으면 기본 1일(오늘). 영구차단·탈퇴 회원은 제외 -->
+    <select id="countNewUsers" resultType="int">
+        SELECT COUNT(*)
+        FROM users
+        WHERE is_deleted = 0
+          AND ban_status &lt;&gt; 'permanent'
+          AND created_at &gt;= DATE_SUB(NOW(), INTERVAL CAST(COALESCE(
+                (SELECT setting_value FROM policy_settings WHERE code = 'dashboard_new_user_period_days'), '1'
+              ) AS SIGNED) DAY)
+    </select>
+
+    <!-- 기간은 policy_settings 에서 로드, 없으면 기본 1일(오늘) -->
+    <select id="countNewPosts" resultType="int">
+        SELECT COUNT(*)
+        FROM posts
+        WHERE state &lt;&gt; 'deleted'
+          AND created_at &gt;= DATE_SUB(NOW(), INTERVAL CAST(COALESCE(
+                (SELECT setting_value FROM policy_settings WHERE code = 'dashboard_new_post_period_days'), '1'
+              ) AS SIGNED) DAY)
+    </select>
+
+    <!-- 처리 대기 신고 건수: 신고 로그를 대상 타입별로 게시글/댓글에 조인해 유효 대상만 집계 -->
+    <select id="countPendingReports" resultType="int">
+        SELECT COUNT(*)
+        FROM (
+            SELECT r.report_id
+            FROM reports_log r
+            INNER JOIN posts p ON r.target_type = 'post' AND r.target_id = p.post_id
+            WHERE r.status = 'pending'
+            UNION ALL
+            SELECT r.report_id
+            FROM reports_log r
+            INNER JOIN comments c ON r.target_type = 'comment' AND r.target_id = c.comment_id
+            WHERE r.status = 'pending'
+        ) pending
+    </select>
+
+    <select id="countTotalUsers" resultType="long">
+        SELECT COUNT(*)
+        FROM users
+        WHERE is_deleted = 0
+          AND ban_status &lt;&gt; 'permanent'
+    </select>
+
+    <!-- 게시글 신고 + 댓글 신고를 통합해 최신순 N건. 댓글 신고는 소속 게시글의 제목/게시판을 보여준다 -->
+    <select id="findRecentReports" resultType="com.back.admin.dashboard.dto.RecentReportResponse">
+        SELECT targetType, boardName, title, reportedAt
+        FROM (
+            SELECT 'post' AS targetType, b.name AS boardName, p.title AS title, r.created_at AS reportedAt
+            FROM reports_log r
+            INNER JOIN posts p ON r.target_type = 'post' AND r.target_id = p.post_id
+            INNER JOIN boards b ON p.board_id = b.board_id
+            UNION ALL
+            SELECT 'comment' AS targetType, b.name AS boardName, p2.title AS title, r.created_at AS reportedAt
+            FROM reports_log r
+            INNER JOIN comments c ON r.target_type = 'comment' AND r.target_id = c.comment_id
+            INNER JOIN posts p2 ON c.post_id = p2.post_id
+            INNER JOIN boards b ON p2.board_id = b.board_id
+        ) recent
+        ORDER BY reportedAt DESC
+        LIMIT #{limit}
+    </select>
+
+    <select id="findRecentUsers" resultType="com.back.admin.dashboard.dto.RecentUserResponse">
+        SELECT user_id AS userId, login_id AS loginId, name, member_type AS memberType, created_at AS createdAt
+        FROM users
+        WHERE is_deleted = 0
+        ORDER BY created_at DESC
+        LIMIT #{limit}
+    </select>
+
+</mapper>

--- a/src/main/resources/mapper/mypage/profile/MyPageMapper.xml
+++ b/src/main/resources/mapper/mypage/profile/MyPageMapper.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.back.mypage.profile.mapper.MyPageMapper">
+
+    <select id="findBasicInfo" resultType="com.back.mypage.profile.dto.MyPageBasicInfoRow">
+        SELECT login_id AS loginId, name, created_at AS joinedAt
+        FROM users
+        WHERE user_id = #{userId} AND is_deleted = 0
+    </select>
+
+    <select id="countMyPosts" resultType="int">
+        SELECT COUNT(*)
+        FROM posts
+        WHERE user_id = #{userId} AND state = 'normal'
+    </select>
+
+    <select id="countMyComments" resultType="int">
+        SELECT COUNT(*)
+        FROM comments
+        WHERE user_id = #{userId} AND state = 'normal'
+    </select>
+
+    <!-- post_likes 는 소프트삭제 예외(좋아요 토글=행 삭제) -->
+    <select id="countMyLikedPosts" resultType="int">
+        SELECT COUNT(*)
+        FROM post_likes pl
+        INNER JOIN posts p ON pl.post_id = p.post_id
+        WHERE pl.user_id = #{userId} AND p.state = 'normal'
+    </select>
+
+    <select id="countMyPostsInPeriod" resultType="int">
+        SELECT COUNT(*)
+        FROM posts
+        WHERE user_id = #{userId} AND state = 'normal'
+          AND created_at &gt;= #{from} AND created_at &lt; #{to}
+    </select>
+
+    <select id="countMyCommentsInPeriod" resultType="int">
+        SELECT COUNT(*)
+        FROM comments
+        WHERE user_id = #{userId} AND state = 'normal'
+          AND created_at &gt;= #{from} AND created_at &lt; #{to}
+    </select>
+
+    <!-- 좋아요엔 시간 기록이 없어 "이번 학기에 내가 쓴 글"의 created_at 기준으로 받은 좋아요를 센다 -->
+    <select id="countMyReceivedLikesInPeriod" resultType="int">
+        SELECT COUNT(*)
+        FROM posts p
+        INNER JOIN post_likes pl ON pl.post_id = p.post_id
+        WHERE p.user_id = #{userId} AND p.state = 'normal'
+          AND p.created_at &gt;= #{from} AND p.created_at &lt; #{to}
+    </select>
+
+    <select id="findPolicySetting" resultType="string">
+        SELECT setting_value FROM policy_settings WHERE code = #{code}
+    </select>
+
+</mapper>


### PR DESCRIPTION
## Summary
- **관리자 대시보드** (`GET /api/admin/dashboard`): 신규 가입자/신규 게시글(policy_settings로 기간 설정, 영구차단·탈퇴 회원 제외) + 처리 대기 신고 + 전체 회원 수(영구차단·탈퇴 제외) + 최근 신고 5건(게시판명/글제목/날짜) + 최근 가입 회원 5명(재학/졸업 구분/아이디/이름/가입일). 일정 달력·월별 일정은 기존 `GET /api/event`를 그대로 재사용(신규 엔드포인트 없음).
- **마이페이지 프로필/활동 요약** (`GET /api/user/mypage`): 전체 기간 작성글/작성한 댓글/좋아요 누른 글 수 + 이번 학기 활동 요약(작성한 글/댓글/받은 좋아요). 학기 기준월은 policy_settings(`semester1_start_month`/`semester2_start_month`)로 설정.
- **로그인 상태 비밀번호 변경** (`PATCH /api/user/mypage/password/reset`): 현재 비밀번호 재확인 + 새 비밀번호/확인 일치 검증 + 회원가입과 동일한 정책(`signup_password_regex`) 재사용. (8/16에 한 번 구현 후 담당자 이관 목적으로만 롤백된 기능을 재구현 + 정책 로딩 방식으로 개선)

## DB 반영 필요 (팀 컨벤션상 .sql 파일 미포함 — docs/integration-20260814/CHECKLIST.md에 기록함)
```sql
INSERT INTO `policy_settings` (code, setting_value, description) VALUES
('dashboard_new_user_period_days', '1', '관리자 대시보드 신규 가입자 집계 기간(일)'),
('dashboard_new_post_period_days', '1', '관리자 대시보드 신규 게시글 집계 기간(일)'),
('semester1_start_month', '3', '1학기 시작월 (마이페이지 이번 학기 활동 요약 기준)'),
('semester2_start_month', '9', '2학기 시작월 (마이페이지 이번 학기 활동 요약 기준)');
```
값이 없어도 코드 기본값(1일 / 3월·9월)으로 동작합니다.

## Test plan
- [x] `./gradlew compileJava` 성공
- [x] `./gradlew test --tests PilsaBackendApplicationTests` 성공 (MyBatis XML 매핑 포함 컨텍스트 로딩 확인)
- [ ] qa_pilsa에 위 policy_settings 4건 반영
- [ ] Swagger로 3개 엔드포인트 실제 호출 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)