### PR TITLE
[BE] 마이페이지 활동 목록 3종 (내 글/내 댓글/좋아요 누른 글)

### DIFF
--- a/src/main/java/com/back/mypage/activity/controller/MyPageActivityController.java
+++ b/src/main/java/com/back/mypage/activity/controller/MyPageActivityController.java
@@ -1,0 +1,62 @@
+package com.back.mypage.activity.controller;
+
+import com.back.mypage.activity.dto.MyCommentPageResponse;
+import com.back.mypage.activity.dto.MyPostPageResponse;
+import com.back.mypage.activity.service.MyPageActivityService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "마이페이지-활동목록",
+        description = "마이페이지 상단 통계 클릭 시 나오는 목록 — 내가 쓴 글 / 내가 쓴 댓글(대댓글 포함) / 좋아요 누른 글. " +
+                "블라인드·삭제(state!='normal')는 제외. 졸업 후에도 전부 노출(재학/졸업 시점 컬럼 없음).")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/user/mypage")
+public class MyPageActivityController {
+
+    private final MyPageActivityService myPageActivityService;
+
+    @Operation(summary = "내가 쓴 글",
+            description = "필터: boardId(선택)/keyword(선택), 정렬 sort(created|viewCount, 기본 created), 페이징. " +
+                    "응답 posts[]: postId/boardId/boardName/title/likeCount/viewCount/created + totalPages/totalCount.")
+    @GetMapping("/posts")
+    public ResponseEntity<MyPostPageResponse> getMyPosts(
+            @RequestParam(value = "page", defaultValue = "1") int page,
+            @RequestParam(value = "size", defaultValue = "10") int size,
+            @RequestParam(value = "boardId", required = false) Long boardId,
+            @RequestParam(value = "keyword", required = false) String keyword,
+            @RequestParam(value = "sort", defaultValue = "created") String sort) {
+        return ResponseEntity.ok(myPageActivityService.getMyPosts(page, size, boardId, keyword, sort));
+    }
+
+    @Operation(summary = "내가 쓴 댓글 (대댓글 포함)",
+            description = "원글 제목 조인. 필터: boardId(원글 기준)/keyword(댓글·원글제목), 최신순, 페이징. " +
+                    "응답 comments[]: commentId/postId/boardId/postTitle/content/created + totalPages/totalCount.")
+    @GetMapping("/comments")
+    public ResponseEntity<MyCommentPageResponse> getMyComments(
+            @RequestParam(value = "page", defaultValue = "1") int page,
+            @RequestParam(value = "size", defaultValue = "10") int size,
+            @RequestParam(value = "boardId", required = false) Long boardId,
+            @RequestParam(value = "keyword", required = false) String keyword) {
+        return ResponseEntity.ok(myPageActivityService.getMyComments(page, size, boardId, keyword));
+    }
+
+    @Operation(summary = "좋아요 누른 글",
+            description = "필터: boardId(선택)/keyword(선택), 정렬 sort(created=최근 좋아요순|viewCount), 페이징. " +
+                    "응답 posts[]: postId/boardId/boardName/title/likeCount/viewCount/created + totalPages/totalCount.")
+    @GetMapping("/likes")
+    public ResponseEntity<MyPostPageResponse> getMyLikedPosts(
+            @RequestParam(value = "page", defaultValue = "1") int page,
+            @RequestParam(value = "size", defaultValue = "10") int size,
+            @RequestParam(value = "boardId", required = false) Long boardId,
+            @RequestParam(value = "keyword", required = false) String keyword,
+            @RequestParam(value = "sort", defaultValue = "created") String sort) {
+        return ResponseEntity.ok(myPageActivityService.getMyLikedPosts(page, size, boardId, keyword, sort));
+    }
+}

--- a/src/main/java/com/back/mypage/activity/dto/MyCommentPageResponse.java
+++ b/src/main/java/com/back/mypage/activity/dto/MyCommentPageResponse.java
@@ -1,0 +1,18 @@
+package com.back.mypage.activity.dto;
+
+import java.util.List;
+import lombok.Getter;
+
+// '내가 쓴 댓글' 페이지 응답
+@Getter
+public class MyCommentPageResponse {
+    private final int totalPages;
+    private final long totalCount;
+    private final List<MyCommentRow> comments;
+
+    public MyCommentPageResponse(int totalPages, long totalCount, List<MyCommentRow> comments) {
+        this.totalPages = totalPages;
+        this.totalCount = totalCount;
+        this.comments = comments;
+    }
+}

--- a/src/main/java/com/back/mypage/activity/dto/MyCommentRow.java
+++ b/src/main/java/com/back/mypage/activity/dto/MyCommentRow.java
@@ -1,0 +1,17 @@
+package com.back.mypage.activity.dto;
+
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.Setter;
+
+// 마이페이지 '내가 쓴 댓글' 목록 한 줄 (대댓글 포함, MyBatis 매핑)
+@Getter
+@Setter
+public class MyCommentRow {
+    private Long commentId;
+    private Long postId;         // 원글 이동용
+    private Long boardId;        // 원글 이동용 (프론트 라우팅)
+    private String postTitle;    // 원글 제목
+    private String content;      // 댓글 내용
+    private LocalDateTime created;
+}

--- a/src/main/java/com/back/mypage/activity/dto/MyPostPageResponse.java
+++ b/src/main/java/com/back/mypage/activity/dto/MyPostPageResponse.java
@@ -1,0 +1,18 @@
+package com.back.mypage.activity.dto;
+
+import java.util.List;
+import lombok.Getter;
+
+// '내가 쓴 글' / '좋아요 누른 글' 페이지 응답
+@Getter
+public class MyPostPageResponse {
+    private final int totalPages;
+    private final long totalCount;   // 필터 반영된 총 개수(페이지네이션용)
+    private final List<MyPostRow> posts;
+
+    public MyPostPageResponse(int totalPages, long totalCount, List<MyPostRow> posts) {
+        this.totalPages = totalPages;
+        this.totalCount = totalCount;
+        this.posts = posts;
+    }
+}

--- a/src/main/java/com/back/mypage/activity/dto/MyPostRow.java
+++ b/src/main/java/com/back/mypage/activity/dto/MyPostRow.java
@@ -1,0 +1,18 @@
+package com.back.mypage.activity.dto;
+
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.Setter;
+
+// 마이페이지 '내가 쓴 글' / '좋아요 누른 글' 목록 한 줄 (MyBatis 매핑)
+@Getter
+@Setter
+public class MyPostRow {
+    private Long postId;
+    private Long boardId;        // 원글 이동용 (프론트 라우팅)
+    private String boardName;    // 게시판 한글명 (내가 쓴 글에서 노출)
+    private String title;
+    private int likeCount;
+    private int viewCount;
+    private LocalDateTime created;
+}

--- a/src/main/java/com/back/mypage/activity/mapper/MyPageActivityMapper.java
+++ b/src/main/java/com/back/mypage/activity/mapper/MyPageActivityMapper.java
@@ -1,0 +1,36 @@
+package com.back.mypage.activity.mapper;
+
+import com.back.mypage.activity.dto.MyCommentRow;
+import com.back.mypage.activity.dto.MyPostRow;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+
+@Mapper
+public interface MyPageActivityMapper {
+
+    // 탭 1: 내가 쓴 글
+    List<MyPostRow> findMyPosts(@Param("userId") Long userId, @Param("boardId") Long boardId,
+                                @Param("keyword") String keyword, @Param("sort") String sort,
+                                @Param("offset") int offset, @Param("size") int size);
+
+    long countMyPosts(@Param("userId") Long userId, @Param("boardId") Long boardId,
+                      @Param("keyword") String keyword);
+
+    // 탭 2: 내가 쓴 댓글 (대댓글 포함)
+    List<MyCommentRow> findMyComments(@Param("userId") Long userId, @Param("boardId") Long boardId,
+                                      @Param("keyword") String keyword,
+                                      @Param("offset") int offset, @Param("size") int size);
+
+    long countMyComments(@Param("userId") Long userId, @Param("boardId") Long boardId,
+                         @Param("keyword") String keyword);
+
+    // 탭 3: 좋아요 누른 글
+    List<MyPostRow> findMyLikedPosts(@Param("userId") Long userId, @Param("boardId") Long boardId,
+                                     @Param("keyword") String keyword, @Param("sort") String sort,
+                                     @Param("offset") int offset, @Param("size") int size);
+
+    long countMyLikedPosts(@Param("userId") Long userId, @Param("boardId") Long boardId,
+                           @Param("keyword") String keyword);
+}

--- a/src/main/java/com/back/mypage/activity/service/MyPageActivityService.java
+++ b/src/main/java/com/back/mypage/activity/service/MyPageActivityService.java
@@ -1,0 +1,16 @@
+package com.back.mypage.activity.service;
+
+import com.back.mypage.activity.dto.MyCommentPageResponse;
+import com.back.mypage.activity.dto.MyPostPageResponse;
+
+public interface MyPageActivityService {
+
+    // 내가 쓴 글
+    MyPostPageResponse getMyPosts(int page, int size, Long boardId, String keyword, String sort);
+
+    // 내가 쓴 댓글 (대댓글 포함)
+    MyCommentPageResponse getMyComments(int page, int size, Long boardId, String keyword);
+
+    // 좋아요 누른 글
+    MyPostPageResponse getMyLikedPosts(int page, int size, Long boardId, String keyword, String sort);
+}

--- a/src/main/java/com/back/mypage/activity/service/MyPageActivityServiceImpl.java
+++ b/src/main/java/com/back/mypage/activity/service/MyPageActivityServiceImpl.java
@@ -1,0 +1,55 @@
+package com.back.mypage.activity.service;
+
+import com.back.global.security.AuthUtils;
+import com.back.mypage.activity.dto.MyCommentPageResponse;
+import com.back.mypage.activity.dto.MyCommentRow;
+import com.back.mypage.activity.dto.MyPostPageResponse;
+import com.back.mypage.activity.dto.MyPostRow;
+import com.back.mypage.activity.mapper.MyPageActivityMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MyPageActivityServiceImpl implements MyPageActivityService {
+
+    private final MyPageActivityMapper mapper;
+
+    @Override
+    public MyPostPageResponse getMyPosts(int page, int size, Long boardId, String keyword, String sort) {
+        Long userId = AuthUtils.currentUserId();
+        long totalCount = mapper.countMyPosts(userId, boardId, keyword);
+        List<MyPostRow> posts = mapper.findMyPosts(userId, boardId, keyword, sort, offset(page, size), size);
+        return new MyPostPageResponse(totalPages(totalCount, size), totalCount, posts);
+    }
+
+    @Override
+    public MyCommentPageResponse getMyComments(int page, int size, Long boardId, String keyword) {
+        Long userId = AuthUtils.currentUserId();
+        long totalCount = mapper.countMyComments(userId, boardId, keyword);
+        List<MyCommentRow> comments = mapper.findMyComments(userId, boardId, keyword, offset(page, size), size);
+        return new MyCommentPageResponse(totalPages(totalCount, size), totalCount, comments);
+    }
+
+    @Override
+    public MyPostPageResponse getMyLikedPosts(int page, int size, Long boardId, String keyword, String sort) {
+        Long userId = AuthUtils.currentUserId();
+        long totalCount = mapper.countMyLikedPosts(userId, boardId, keyword);
+        List<MyPostRow> posts = mapper.findMyLikedPosts(userId, boardId, keyword, sort, offset(page, size), size);
+        return new MyPostPageResponse(totalPages(totalCount, size), totalCount, posts);
+    }
+
+    // page(1-base)·size 정규화 후 offset 계산
+    private int offset(int page, int size) {
+        return (Math.max(page, 1) - 1) * Math.max(size, 1);
+    }
+
+    private int totalPages(long totalCount, int size) {
+        int s = Math.max(size, 1);
+        return (int) ((totalCount + s - 1) / s); // ceil
+    }
+}

--- a/src/main/resources/mapper/mypage/activity/MyPageActivityMapper.xml
+++ b/src/main/resources/mapper/mypage/activity/MyPageActivityMapper.xml
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.back.mypage.activity.mapper.MyPageActivityMapper">
+
+    <!-- ============================================================
+         마이페이지 활동 목록 (내 글 / 내 댓글 / 좋아요 누른 글)
+         공통 규칙:
+          - state='normal' 만 노출 (블라인드·삭제 제외 — 학생 화면 대전제)
+          - 졸업 후에도 전부 노출 (재학/졸업 시점 컬럼이 없어 "재학생 때만" 필터 불가)
+          - 필터: boardId(선택) / keyword(선택), 정렬: sort(created|viewCount)
+         ============================================================ -->
+
+    <!-- ── 탭 1: 내가 쓴 글 ─────────────────────────────────── -->
+    <select id="findMyPosts" resultType="com.back.mypage.activity.dto.MyPostRow">
+        SELECT
+            p.post_id     AS postId,
+            p.board_id    AS boardId,
+            b.name        AS boardName,
+            p.title,
+            p.view_count  AS viewCount,
+            p.created_at  AS created,
+            (SELECT COUNT(*) FROM post_likes pl WHERE pl.post_id = p.post_id) AS likeCount
+        FROM posts p
+        INNER JOIN boards b ON p.board_id = b.board_id
+        WHERE p.user_id = #{userId}
+          AND p.state = 'normal'
+        <if test="boardId != null">AND p.board_id = #{boardId}</if>
+        <if test="keyword != null and keyword != ''">
+            AND (p.title LIKE CONCAT('%', #{keyword}, '%')
+                 OR p.content LIKE CONCAT('%', #{keyword}, '%'))
+        </if>
+        ORDER BY
+        <choose>
+            <when test="sort == 'viewCount'">p.view_count DESC, p.post_id DESC</when>
+            <otherwise>p.created_at DESC, p.post_id DESC</otherwise>
+        </choose>
+        LIMIT #{size} OFFSET #{offset}
+    </select>
+
+    <select id="countMyPosts" resultType="long">
+        SELECT COUNT(*)
+        FROM posts p
+        WHERE p.user_id = #{userId}
+          AND p.state = 'normal'
+        <if test="boardId != null">AND p.board_id = #{boardId}</if>
+        <if test="keyword != null and keyword != ''">
+            AND (p.title LIKE CONCAT('%', #{keyword}, '%')
+                 OR p.content LIKE CONCAT('%', #{keyword}, '%'))
+        </if>
+    </select>
+
+    <!-- ── 탭 2: 내가 쓴 댓글 (대댓글 포함) ─────────────────────
+         원글이 블라인드/삭제(state!='normal')면 그 댓글도 숨김.        -->
+    <select id="findMyComments" resultType="com.back.mypage.activity.dto.MyCommentRow">
+        SELECT
+            cm.comment_id AS commentId,
+            cm.content,
+            cm.created_at AS created,
+            p.post_id     AS postId,
+            p.board_id    AS boardId,
+            p.title       AS postTitle
+        FROM comments cm
+        INNER JOIN posts p ON cm.post_id = p.post_id
+        WHERE cm.user_id = #{userId}
+          AND cm.state = 'normal'
+          AND p.state  = 'normal'
+        <if test="boardId != null">AND p.board_id = #{boardId}</if>
+        <if test="keyword != null and keyword != ''">
+            AND (cm.content LIKE CONCAT('%', #{keyword}, '%')
+                 OR p.title  LIKE CONCAT('%', #{keyword}, '%'))
+        </if>
+        ORDER BY cm.created_at DESC, cm.comment_id DESC
+        LIMIT #{size} OFFSET #{offset}
+    </select>
+
+    <select id="countMyComments" resultType="long">
+        SELECT COUNT(*)
+        FROM comments cm
+        INNER JOIN posts p ON cm.post_id = p.post_id
+        WHERE cm.user_id = #{userId}
+          AND cm.state = 'normal'
+          AND p.state  = 'normal'
+        <if test="boardId != null">AND p.board_id = #{boardId}</if>
+        <if test="keyword != null and keyword != ''">
+            AND (cm.content LIKE CONCAT('%', #{keyword}, '%')
+                 OR p.title  LIKE CONCAT('%', #{keyword}, '%'))
+        </if>
+    </select>
+
+    <!-- ── 탭 3: 좋아요 누른 글 ─────────────────────────────────
+         내가 좋아요 누른 글 중, 지금 정상 노출(state='normal')인 것만.    -->
+    <select id="findMyLikedPosts" resultType="com.back.mypage.activity.dto.MyPostRow">
+        SELECT
+            p.post_id     AS postId,
+            p.board_id    AS boardId,
+            b.name        AS boardName,
+            p.title,
+            p.view_count  AS viewCount,
+            p.created_at  AS created,
+            (SELECT COUNT(*) FROM post_likes l WHERE l.post_id = p.post_id) AS likeCount
+        FROM post_likes pl
+        INNER JOIN posts p  ON pl.post_id = p.post_id
+        INNER JOIN boards b ON p.board_id = b.board_id
+        WHERE pl.user_id = #{userId}
+          AND p.state = 'normal'
+        <if test="boardId != null">AND p.board_id = #{boardId}</if>
+        <if test="keyword != null and keyword != ''">
+            AND (p.title LIKE CONCAT('%', #{keyword}, '%')
+                 OR p.content LIKE CONCAT('%', #{keyword}, '%'))
+        </if>
+        ORDER BY
+        <choose>
+            <when test="sort == 'viewCount'">p.view_count DESC, p.post_id DESC</when>
+            <otherwise>pl.created_at DESC, p.post_id DESC</otherwise>
+        </choose>
+        LIMIT #{size} OFFSET #{offset}
+    </select>
+
+    <select id="countMyLikedPosts" resultType="long">
+        SELECT COUNT(*)
+        FROM post_likes pl
+        INNER JOIN posts p ON pl.post_id = p.post_id
+        WHERE pl.user_id = #{userId}
+          AND p.state = 'normal'
+        <if test="boardId != null">AND p.board_id = #{boardId}</if>
+        <if test="keyword != null and keyword != ''">
+            AND (p.title LIKE CONCAT('%', #{keyword}, '%')
+                 OR p.content LIKE CONCAT('%', #{keyword}, '%'))
+        </if>
+    </select>
+
+</mapper>


### PR DESCRIPTION
## 기능
마이페이지 상단 통계(작성글/작성한 댓글/좋아요 누른 글)를 **클릭했을 때 나오는 목록** 3종. (상단 숫자 자체는 기존 `GET /api/user/mypage` profile 요약이 담당)

| 엔드포인트 | 명세 | 응답 |
| --- | --- | --- |
| `GET /api/user/mypage/posts` | api_endpoints #30 | `{totalPages, totalCount, posts[]}` |
| `GET /api/user/mypage/comments` | #23 | `{totalPages, totalCount, comments[]}` |
| `GET /api/user/mypage/likes` | #24 | `{totalPages, totalCount, posts[]}` |

- posts[]: `postId, boardId, boardName, title, likeCount, viewCount, created`
- comments[]: `commentId, postId, boardId, postTitle, content, created` (원글 조인, **대댓글 포함**)
- 공통 쿼리: `?page&size&boardId&keyword&sort` (auth=MEMBER)

## 정책 결정 & 근거

### 1. 재학생/졸업생 콘텐츠 **전부 노출** (졸업 후 활동도 포함)
"재학생 때 작성/좋아요한 것만 보여주자"(수민 기획 팀장 선호)는 **현재 스키마로 구현 불가**라 전부 노출로 확정. 이유:
- **콘텐츠(posts/comments/post_likes)에 "작성 당시 신분"이 없음** — `created_at`(작성 시각)만 있고, 그때 작성자가 재학생이었는지/졸업생이었는지 기록이 없다.
- **`users`에 졸업(전환) 시점 컬럼이 없음** — `member_type`은 *현재* 신분만 나타내고(STUDENT/ALUMNI), 언제 STUDENT→ALUMNI로 바뀌었는지는 저장하지 않는다. `updated_at`은 프로필 아무 수정에도 갱신돼 졸업 시점으로 쓸 수 없다.
- 결국 **"created_at < 졸업 시점" 필터를 걸 기준값 자체가 DB에 없다.**
- 구현하려면 `users.graduated_at`(또는 신분 전환 이력 테이블) 신설이 선행돼야 함 → **별도 스키마 논의 필요**. 그 전까지 전부 노출.

### 2. 블라인드·삭제 제외
세 목록 모두 `state='normal'`만. 내 댓글은 **원글이 블라인드/삭제면 그 댓글도 숨김**(`cm.state='normal' AND p.state='normal'`).

### 3. 졸업 후 수정/삭제(2-1)
글 상세의 권한 문제라 이 목록/통계 범위 밖 — 별도.

## 명세 외 추가 (명세엔 반영 안 함 — PM 판단 대기)
- 명세(api_endpoints)엔 없지만 **좋아요·댓글 응답에 `boardId` 추가**함. 목록에서 원글로 이동하려면 board 컨텍스트가 필요(프론트 라우팅)해서인데, **명세 정본은 건드리지 않고 이 PR에만 반영**해 뒀습니다. 명세 반영 여부는 PM 검토 후 결정.
- (좋아요 응답엔 `boardName`도 포함 — 내 글과 동일 join)

## 구조/컨벤션
- `com.back.mypage.activity` 서브패키지 (기존 `mypage/profile` 스타일), `AuthUtils.currentUserId()` 사용
- SQL은 posts/comments/post_likes/boards 직접 조회, `boards.name`=boardName

## 검증 ✅
- `./gradlew compileJava` 통과, 앱 기동 성공 — MyBatis 매퍼 바인딩·엔드포인트 등록 확인
- **qa_pilsa 실데이터로 3개 쿼리 + count + 필터 변형 직접 실행 → 오류 없음** (예: user 97 = 글 15/댓글 15/좋아요 11, boardName·원글제목·likeCount 정상 반환)
- 컬럼명·조인·`state` 필터가 실제 스키마와 일치함을 확인

## 알아둘 점 (엣지케이스)
- `boards`가 소프트삭제(`state='deleted'`)된 경우 그 게시판의 글이 목록에 남을 수 있음(현재 INNER JOIN은 board row 존재만 확인). **현재 qa_pilsa엔 삭제된 게시판이 없어** 영향 없음. 필요하면 `AND b.state='normal'` 추가 논의.
